### PR TITLE
feat: add support for setting email as env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ npm install -g formanator
 To get started, you'll need to connect Formanator to your Forma account. Here's how the process works:
 
 1. Run `formanator login`.
-2. At the prompt, enter your email address, then hit Enter.
+2. Provide your email in one of the three ways:
+    1. At the prompt, enter your email address, then hit Enter.
+    2. Set the `FORMA_EMAIL` environment variable
+    3. Use the `--email` argument
 3. You'll be sent an email with a magic link. Go to your inbox and copy the link to your clipboard.
 4. At the prompt, paste your magic link, then hit Enter.
 5. You'll be logged in 🥳

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -90,7 +90,7 @@ command
   .name('login')
   .version(VERSION)
   .description('Connect Formanator to your Forma account with a magic link')
-  .option('--email <email>', 'Email address used to log in to Forma')
+  .option('--email <email>', 'Email address used to log in to Forma', process.env.FORMA_EMAIL)
   .action(
     actionRunner(async (opts: Arguments) => {
       const email = opts.email ?? promptForEmail();


### PR DESCRIPTION
I was finding it annoying being prompted for my email every time I needed to re-login. After hopping into the code, I saw there was already support for the command line flag, but personally prefer the `env` variables. So this PR adds support for `FORMA_EMAIL` as an environment variable.

I don't love the naming inconsistency with `FORMA_EMAIL` and `--email`, but since `env` variables are more public, I felt we should make it a bit more unique and less likely to collide with something else that wants an `EMAIL` environment variable.