### PR TITLE
feat: add `list-claims` command for viewing previously submitted claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ When submitting a claim, you need to specify several details like amount, mercha
 
 ### Using GitHub Models to infer claim details
 
-[GitHub Models](https://github.blog/news-insights/product-news/introducing-github-models/) gives a generous free tier for various AI models, so you can do this totally free of charge. 
+[GitHub Models](https://github.blog/news-insights/product-news/introducing-github-models/) gives a generous free tier for various AI models, so you can do this totally free of charge.
 
 You'll just to configure a GitHub personal access token (PAT) with models access:
 
@@ -101,7 +101,7 @@ formanator submit-claim --receipt-path "receipt.jpg"
 
 The LLM will analyze your receipt and extract:
 - Amount
-- Merchant name  
+- Merchant name
 - Purchase date
 - Description of items
 - Appropriate benefit and category
@@ -143,9 +143,21 @@ formanator submit-claim --amount 2.28 \
                         --category "Cables & Cords"
 ```
 
+## Retrieving your claims
+
+You can display a list of all your claims, including their current reimbursement status and claim details.
+
+```bash
+formanator list-claims
+```
+
+Queries are paginated, so you can use the `-p` or `--page` argument to specify paging.
+```bash
+formanator list-claims -p 3
+```
 
 ## Contributing
 
-Changes to this project are verioned using [Semantic Versioning](https://semver.org/) and released to `npm` automatically using [`semantic-release`](https://github.com/semantic-release/semantic-release). 
+Changes to this project are verioned using [Semantic Versioning](https://semver.org/) and released to `npm` automatically using [`semantic-release`](https://github.com/semantic-release/semantic-release).
 
 Commit messages must follow [Angular Commit Message Conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format) so `semantic-release` knows when to release new versions and what version number to use.

--- a/src/commands/list-claims.ts
+++ b/src/commands/list-claims.ts
@@ -1,0 +1,69 @@
+import * as commander from 'commander';
+import Table from 'cli-table';
+
+import { actionRunner } from '../utils.js';
+import { getAccessToken } from '../config.js';
+import { getClaimsList } from '../forma.js';
+import VERSION from '../version.js';
+
+const command = new commander.Command();
+
+interface Arguments {
+  accessToken?: string;
+  page: string;
+}
+
+command
+  .name('list-claims')
+  .version(VERSION)
+  .description('List claims in your Forma account and their current status')
+  .option('--access-token <access_token>', 'Access token used to authenticate with Forma')
+  .option('-p, --page <page>', 'Page number to retrieve (default: 0)', '0')
+  .action(
+    actionRunner(async (opts: Arguments) => {
+      const accessToken = opts.accessToken ?? getAccessToken();
+      const page = parseInt(opts.page, 10);
+
+      if (!accessToken) {
+        throw new Error(
+          "You aren't logged in to Forma. Please run `formanator login` first.",
+        );
+      }
+
+      const claims = await getClaimsList(accessToken, page);
+
+      const table = new Table({
+        head: [
+          'Reimbursement Vendor',
+          'Employee Note',
+          'Amount',
+          'Category',
+          'Subcategory',
+          'Status',
+          'Reimbursement Status',
+          'Payout Status',
+          'Date Processed',
+          'Note',
+        ],
+      });
+
+      for (const claim of claims) {
+        table.push([
+          `${claim.reimbursement_vendor}`,
+          `${claim.employee_note}`,
+          `${claim.amount}`,
+          `${claim.category}`,
+          `${claim.subcategory}`,
+          `${claim.status}`,
+          `${claim.reimbursement_status}`,
+          `${claim.payout_status}`,
+          `${claim.date_processed}`,
+          `${claim.note}`,
+        ]);
+      }
+
+      console.log(table.toString());
+    }),
+  );
+
+export default command;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import * as commander from 'commander';
 import login from './commands/login.js';
 import benefits from './commands/benefits.js';
 import categories from './commands/categories.js';
+import listClaims from './commands/list-claims.js';
 import submitClaim from './commands/submit-claim.js';
 import generateTemplateCsv from './commands/generate-template-csv.js';
 import submitClaimsFromCsv from './commands/submit-claims-from-csv.js';
@@ -19,6 +20,7 @@ program
   .addCommand(login)
   .addCommand(benefits)
   .addCommand(categories)
+  .addCommand(listClaims)
   .addCommand(submitClaim)
   .addCommand(generateTemplateCsv)
   .addCommand(submitClaimsFromCsv)


### PR DESCRIPTION
# New Feature

Command to List Claims in your Forma account. Command supports pagination for historical claims using the `-p` or `--page` flag.

## Usage

Default usage:
```
formanator list-claims
```

Paginated usage
```
formanator list-claims -p 6
```