### PR TITLE
remove -y arg for mcp server in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ You can:
       "command": "/path/to/npx",
       "args": [
         "formanator",
-        "-y",
         "mcp"
       ]
     }


### PR DESCRIPTION
When running `formanator -y mpc`, I get the following error:
```bash
error: unknown option '-y'
```

The mcp server also fails to start in claude desktop with the `-y` arg. 

This change updates the README to remove the `-y` arg from the documentation.