### PR TITLE
fix: handle cases where the LLM returns inferred receipt details wrapped in a Markdown code block

### DIFF
--- a/src/openai.ts
+++ b/src/openai.ts
@@ -174,7 +174,11 @@ export const attemptToInferAllFromReceipt = async (opts: {
   // Parse the JSON response
   let parsedResponse: ReceiptInferenceResult;
   try {
-    parsedResponse = JSON.parse(returnedResponseAsString);
+    const cleanedResponse = returnedResponseAsString
+      .replace(/^```json\s*/, '')
+      .replace(/\s*```$/, '')
+      .trim();
+    parsedResponse = JSON.parse(cleanedResponse);
   } catch (error) {
     throw new Error(
       `Something went wrong while parsing OpenAI's response: ${returnedResponseAsString}. Error: ${error}`,


### PR DESCRIPTION
This PR is an attempt to fix the following error:


```
$ formanator submit-claims-from-directory --directory pending
Found 1 receipt file(s) to process:
  1. filename.pdf


--- Processing receipt 1/1: filename.pdf ---
Analyzing receipt...
❌ Error processing filename.pdf: Something went wrong while parsing OpenAI's response: ```json
{
    "amount": "0",
    "merchant": "Merchant",
    "purchaseDate": "2025-06-21",
    "description": "Desciption",
    "benefit": "Learning, Remote Life, & Wellness",
    "category": "Computer & Laptop Accessories"
}
```. Error: SyntaxError: Unexpected token '`', "```json
{
"... is not valid JSON

--- Summary ---
Processed successfully: 0
Skipped: 1
Total files: 1
```

Confirmed this works as expected with the same receipt PDF.