### PR TITLE
fix: prompt the LLM not to wrap inference results in a JSON code block

### DIFF
--- a/src/openai.ts
+++ b/src/openai.ts
@@ -289,7 +289,7 @@ ${validBenefitsAsList}
 Valid categories:
 ${validCategoriesAsList}
 
-Return ONLY a valid JSON object with these exact field names. Do not include any other text or formatting.`;
+Return ONLY a valid JSON object with these exact field names. Do not include any other text or formatting. Do not wrap the JSON object in a markdown code block syntax.`;
 };
 
 const convertToImageIfNeeded = async (filePath: string): Promise<string> => {


### PR DESCRIPTION
This is a follow up to https://github.com/timrogers/formanator/pull/476.

With this update, I confirmed that the JSON response is not wrapped in the markdown code block, without the following guard I added in https://github.com/timrogers/formanator/pull/476:

```javascript
const cleanedResponse = returnedResponseAsString
      .replace(/^```json\s*/, '')
      .replace(/\s*```$/, '')
      .trim();
```

@timrogers Would you like me to remove this guard in this PR or keep it?