### PR TITLE
feat: only show "Payout status" in `list-claims` output if present for at least one claim

### DIFF
--- a/src/commands/list-claims.ts
+++ b/src/commands/list-claims.ts
@@ -54,13 +54,8 @@ command
         head: tableHeaders,
       });
 
-<<<<<<< Updated upstream
       for (const claim of claims) {
         table.push([
-=======
-      for (const claim of filteredClaims) {
-        const rowData = [
->>>>>>> Stashed changes
           `${claim.reimbursement_vendor}`,
           `${claim.employee_note}`,
           `${claim.amount}`,

--- a/src/commands/list-claims.ts
+++ b/src/commands/list-claims.ts
@@ -33,7 +33,7 @@ command
       const claims = await getClaimsList(accessToken, page);
 
       // Check if any claims have non-null payout_status
-      const hasPayoutStatus = filteredClaims.some(
+      const hasPayoutStatus = claims.some(
         (claim) => claim.payout_status !== null,
       );
 

--- a/src/commands/list-claims.ts
+++ b/src/commands/list-claims.ts
@@ -32,23 +32,35 @@ command
 
       const claims = await getClaimsList(accessToken, page);
 
+      // Check if any claims have non-null payout_status
+      const hasPayoutStatus = filteredClaims.some(
+        (claim) => claim.payout_status !== null,
+      );
+
+      const tableHeaders = [
+        'Reimbursement Vendor',
+        'Employee Note',
+        'Amount',
+        'Category',
+        'Subcategory',
+        'Status',
+        'Reimbursement Status',
+        ...(hasPayoutStatus ? ['Payout Status'] : []),
+        'Date Processed',
+        'Note',
+      ];
+
       const table = new Table({
-        head: [
-          'Reimbursement Vendor',
-          'Employee Note',
-          'Amount',
-          'Category',
-          'Subcategory',
-          'Status',
-          'Reimbursement Status',
-          'Payout Status',
-          'Date Processed',
-          'Note',
-        ],
+        head: tableHeaders,
       });
 
+<<<<<<< Updated upstream
       for (const claim of claims) {
         table.push([
+=======
+      for (const claim of filteredClaims) {
+        const rowData = [
+>>>>>>> Stashed changes
           `${claim.reimbursement_vendor}`,
           `${claim.employee_note}`,
           `${claim.amount}`,
@@ -56,10 +68,11 @@ command
           `${claim.subcategory}`,
           `${claim.status}`,
           `${claim.reimbursement_status}`,
-          `${claim.payout_status}`,
+          ...(hasPayoutStatus ? [`${claim.payout_status}`] : []),
           `${claim.date_processed}`,
           `${claim.note}`,
-        ]);
+        ];
+        table.push(rowData);
       }
 
       console.log(table.toString());

--- a/src/commands/list-claims.ts
+++ b/src/commands/list-claims.ts
@@ -66,8 +66,7 @@ command
           ...(hasPayoutStatus ? [`${claim.payout_status}`] : []),
           `${claim.date_processed}`,
           `${claim.note}`,
-        ];
-        table.push(rowData);
+        ]);
       }
 
       console.log(table.toString());

--- a/src/commands/list-claims.ts
+++ b/src/commands/list-claims.ts
@@ -33,9 +33,7 @@ command
       const claims = await getClaimsList(accessToken, page);
 
       // Check if any claims have non-null payout_status
-      const hasPayoutStatus = claims.some(
-        (claim) => claim.payout_status !== null,
-      );
+      const hasPayoutStatus = claims.some((claim) => claim.payout_status !== null);
 
       const tableHeaders = [
         'Reimbursement Vendor',


### PR DESCRIPTION
I'm not sure if or when this field is ever non-null; it'd be simpler code to just never display it. But since it might be non-null in some case I don't know about, we'll check before dropping the column.