### PR TITLE
feat: use GitHub Copilot CLI as the default inference provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - `src/cli.rs` defines the Clap CLI surface.
 - `src/commands/` contains one handler per subcommand.
 - `src/lib.rs` exposes shared modules such as Forma API access, claim handling, config, prompts, LLM integration, and MCP support.
-- The default feature set includes `mcp`; the crate targets Rust edition 2024 and has an MSRV of Rust 1.88.
+- The default feature set includes `mcp`; the crate targets Rust edition 2024 and has an MSRV of Rust 1.94.
 
 ## Working in this repository
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +83,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,7 +156,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -414,6 +429,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +544,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,11 +603,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -583,7 +639,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -665,10 +721,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -712,7 +788,8 @@ dependencies = [
  "clap",
  "colored",
  "csv",
- "dirs",
+ "dirs 6.0.0",
+ "github-copilot-sdk",
  "httpmock",
  "keyring",
  "open",
@@ -884,6 +961,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "github-copilot-sdk"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2383260850df704ab267eaff873cd67d78745b8a98b6222a37185a56b90295d"
+dependencies = [
+ "async-trait",
+ "dirs 5.0.1",
+ "flate2",
+ "getrandom 0.2.17",
+ "parking_lot",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tar",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "ureq",
+ "uuid",
+ "zip",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,7 +1122,7 @@ dependencies = [
  "similar",
  "stringmetrics",
  "tabwriter",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -1061,7 +1163,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1297,7 +1399,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -1464,6 +1566,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1721,7 +1833,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1743,7 +1855,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1824,13 +1936,24 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1920,7 +2043,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1995,7 +2118,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2049,6 +2172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2354,6 +2478,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,6 +2512,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_cesu8"
@@ -2511,6 +2652,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,11 +2692,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2638,6 +2810,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2844,6 +3017,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2866,6 +3054,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "getrandom 0.4.2",
+]
 
 [[package]]
 name = "valuable"
@@ -3064,6 +3261,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -3141,6 +3347,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3164,6 +3379,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3201,6 +3431,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3213,6 +3449,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3222,6 +3464,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3249,6 +3497,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3258,6 +3512,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3273,6 +3533,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3282,6 +3548,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3402,6 +3674,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3505,7 +3787,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.md"
 categories = ["command-line-utilities"]
 keywords = ["forma", "joinforma", "benefits", "expenses", "claims"]
-rust-version = "1.88"
+rust-version = "1.94"
 
 [dependencies]
 anyhow = "1.0"
@@ -38,6 +38,7 @@ rmcp = { version = "1.7", features = ["server", "transport-io", "macros"], optio
 schemars = { version = "1.2", features = ["derive"], optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
+github-copilot-sdk = { version = "1.0.1", default-features = false }
 
 [features]
 default = ["mcp"]

--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ Once a day, Formanator checks GitHub for a newer release. When one is available,
 
 ### Configuring an LLM provider (optional, but recommended)
 
-When submitting a claim you can either provide every detail manually or let an LLM infer them. Two providers are supported:
+When submitting a claim you can either provide every detail manually or let an LLM infer them. Three providers are supported:
 
-- **GitHub Models** — free, with a generous quota. Set the `GITHUB_TOKEN` environment variable to a GitHub Personal Access Token with **read access to GitHub Models**, or pass `--github-token`.
+- **GitHub Copilot CLI** — _the default._ If you don't configure OpenAI or GitHub Models, Formanator uses the [GitHub Copilot CLI](https://github.com/features/copilot/cli) for inference. Formanator detects the `copilot` binary on your `PATH` automatically; if it lives elsewhere, set the `COPILOT_CLI_PATH` environment variable or pass `--copilot-cli-path` with the path to the binary.
 - **OpenAI** — billed to your OpenAI account. Set the `OPENAI_API_KEY` environment variable, or pass `--openai-api-key`.
+- **GitHub Models** — _deprecated; may be removed in a future release._ Free, with a generous quota. Set the `GITHUB_MODELS_TOKEN` environment variable to a GitHub Personal Access Token with **read access to GitHub Models**, or pass `--github-models-token`. When this provider is used, Formanator prints a deprecation warning to stderr.
 
-If both are configured, Formanator prefers OpenAI.
+If multiple are configured, Formanator prefers OpenAI, then GitHub Models, and otherwise falls back to the GitHub Copilot CLI.
 
 ### Submitting claims in bulk
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -117,9 +117,12 @@ pub struct SubmitClaimArgs {
     /// OpenAI API key used to infer claim details. Defaults to the `OPENAI_API_KEY` environment variable.
     #[arg(long, env = "OPENAI_API_KEY")]
     pub openai_api_key: Option<String>,
-    /// GitHub token used to infer claim details via GitHub Models. Defaults to the `GITHUB_TOKEN` environment variable.
-    #[arg(long, env = "GITHUB_TOKEN")]
-    pub github_token: Option<String>,
+    /// GitHub Models token used to infer claim details via GitHub Models. Defaults to the `GITHUB_MODELS_TOKEN` environment variable. Deprecated: prefer --openai-api-key.
+    #[arg(long, env = "GITHUB_MODELS_TOKEN")]
+    pub github_models_token: Option<String>,
+    /// Path to the GitHub Copilot CLI binary, used for inference when no OpenAI API key or GitHub token is provided. Defaults to the `COPILOT_CLI_PATH` environment variable, otherwise auto-detected on your PATH.
+    #[arg(long, env = "COPILOT_CLI_PATH")]
+    pub copilot_cli_path: Option<PathBuf>,
     /// Run through the entire flow without actually submitting the claim.
     #[arg(long)]
     pub dry_run: bool,
@@ -146,9 +149,12 @@ pub struct SubmitClaimsFromCsvArgs {
     /// OpenAI API key used to infer claim details for rows that leave columns blank.
     #[arg(long, env = "OPENAI_API_KEY")]
     pub openai_api_key: Option<String>,
-    /// GitHub token used to infer claim details via GitHub Models.
-    #[arg(long, env = "GITHUB_TOKEN")]
-    pub github_token: Option<String>,
+    /// GitHub Models token used to infer claim details via GitHub Models. Defaults to the `GITHUB_MODELS_TOKEN` environment variable. Deprecated: prefer --openai-api-key.
+    #[arg(long, env = "GITHUB_MODELS_TOKEN")]
+    pub github_models_token: Option<String>,
+    /// Path to the GitHub Copilot CLI binary, used for inference when no OpenAI API key or GitHub token is provided. Defaults to the `COPILOT_CLI_PATH` environment variable, otherwise auto-detected on your PATH.
+    #[arg(long, env = "COPILOT_CLI_PATH")]
+    pub copilot_cli_path: Option<PathBuf>,
     /// Run through the entire flow without actually submitting the claims.
     #[arg(long)]
     pub dry_run: bool,
@@ -171,9 +177,12 @@ pub struct SubmitClaimsFromDirectoryArgs {
     /// OpenAI API key used to infer claim details from receipts.
     #[arg(long, env = "OPENAI_API_KEY")]
     pub openai_api_key: Option<String>,
-    /// GitHub token used to infer claim details via GitHub Models.
-    #[arg(long, env = "GITHUB_TOKEN")]
-    pub github_token: Option<String>,
+    /// GitHub Models token used to infer claim details via GitHub Models. Defaults to the `GITHUB_MODELS_TOKEN` environment variable. Deprecated: prefer --openai-api-key.
+    #[arg(long, env = "GITHUB_MODELS_TOKEN")]
+    pub github_models_token: Option<String>,
+    /// Path to the GitHub Copilot CLI binary, used for inference when no OpenAI API key or GitHub token is provided. Defaults to the `COPILOT_CLI_PATH` environment variable, otherwise auto-detected on your PATH.
+    #[arg(long, env = "COPILOT_CLI_PATH")]
+    pub copilot_cli_path: Option<PathBuf>,
     /// Run through the entire flow without actually submitting the claims.
     #[arg(long)]
     pub dry_run: bool,

--- a/src/commands/submit_claim.rs
+++ b/src/commands/submit_claim.rs
@@ -22,7 +22,8 @@ pub fn run(args: SubmitClaimArgs) -> Result<()> {
         description,
         receipt_path,
         openai_api_key,
-        github_token,
+        github_models_token,
+        copilot_cli_path,
         dry_run,
         verbose: _,
         ..
@@ -71,7 +72,6 @@ pub fn run(args: SubmitClaimArgs) -> Result<()> {
         || merchant.is_some()
         || purchase_date.is_some()
         || description.is_some();
-    let has_llm_key = openai_api_key.is_some() || github_token.is_some();
 
     if let Some(claim) = has_all_manual {
         let opts = claim_input_to_create_options(&claim, &access_token)?;
@@ -80,14 +80,16 @@ pub fn run(args: SubmitClaimArgs) -> Result<()> {
         } else {
             create_claim(&opts)?;
         }
-    } else if !has_some_manual && has_llm_key {
-        // Full receipt inference mode
+    } else if !has_some_manual {
+        // Full receipt inference mode. Uses OpenAI/GitHub Models when a key is
+        // provided, otherwise falls back to the GitHub Copilot CLI.
         let benefits = get_benefits_with_categories(&access_token)?;
         let inferred = infer_all_from_receipt(
             &receipt_path[0],
             &benefits,
             openai_api_key.as_deref(),
-            github_token.as_deref(),
+            github_models_token.as_deref(),
+            copilot_cli_path.as_deref(),
         )?;
 
         println!(
@@ -121,22 +123,22 @@ pub fn run(args: SubmitClaimArgs) -> Result<()> {
         } else {
             create_claim(&opts)?;
         }
-    } else if has_llm_key
-        && let (Some(merchant), Some(description), Some(amount), Some(purchase_date)) = (
-            merchant.clone(),
-            description.clone(),
-            amount.clone(),
-            purchase_date.clone(),
-        )
-    {
-        // Legacy mode: infer benefit and category only.
+    } else if let (Some(merchant), Some(description), Some(amount), Some(purchase_date)) = (
+        merchant.clone(),
+        description.clone(),
+        amount.clone(),
+        purchase_date.clone(),
+    ) {
+        // Legacy mode: infer benefit and category only. Uses OpenAI/GitHub
+        // Models when a key is provided, otherwise the GitHub Copilot CLI.
         let benefits = get_benefits_with_categories(&access_token)?;
         let inferred = infer_category_and_benefit(
             &merchant,
             &description,
             &benefits,
             openai_api_key.as_deref(),
-            github_token.as_deref(),
+            github_models_token.as_deref(),
+            copilot_cli_path.as_deref(),
         )?;
 
         println!(
@@ -163,7 +165,7 @@ pub fn run(args: SubmitClaimArgs) -> Result<()> {
         }
     } else {
         bail!(
-            "You must either provide all claim details (--benefit, --category, --amount, --merchant, --purchase-date, --description), or provide an OpenAI API key or GitHub token with either: (1) just a receipt for full inference, or (2) all details except --benefit and --category to infer them."
+            "You must either provide all claim details (--benefit, --category, --amount, --merchant, --purchase-date, --description), or provide either: (1) just a receipt for full inference, or (2) all details except --benefit and --category to infer them. Inference uses the GitHub Copilot CLI by default, or OpenAI / GitHub Models if --openai-api-key / --github-models-token is set."
         );
     }
 

--- a/src/commands/submit_claims_from_csv.rs
+++ b/src/commands/submit_claims_from_csv.rs
@@ -33,7 +33,6 @@ pub fn run(args: SubmitClaimsFromCsvArgs) -> Result<()> {
         );
 
         let result = (|| -> Result<()> {
-            let has_llm_key = args.openai_api_key.is_some() || args.github_token.is_some();
             let benefit_category_empty = claim.benefit.is_empty() && claim.category.is_empty();
             let other_details_empty = claim.amount.is_empty()
                 && claim.merchant.is_empty()
@@ -52,7 +51,7 @@ pub fn run(args: SubmitClaimsFromCsvArgs) -> Result<()> {
                 } else {
                     create_claim(&opts)
                 }
-            } else if has_llm_key && benefit_category_empty && other_details_empty {
+            } else if benefit_category_empty && other_details_empty {
                 if claim.receipt_path.is_empty() {
                     anyhow::bail!(
                         "To infer all claim details from the receipt, you must provide at least one path in the `receiptPath` column."
@@ -62,7 +61,8 @@ pub fn run(args: SubmitClaimsFromCsvArgs) -> Result<()> {
                     &claim.receipt_path[0],
                     &benefits,
                     args.openai_api_key.as_deref(),
-                    args.github_token.as_deref(),
+                    args.github_models_token.as_deref(),
+                    args.copilot_cli_path.as_deref(),
                 )?;
                 println!("Inferred amount: {}", inferred.amount);
                 println!("Inferred merchant: {}", inferred.merchant);
@@ -83,13 +83,14 @@ pub fn run(args: SubmitClaimsFromCsvArgs) -> Result<()> {
                 } else {
                     create_claim(&opts)
                 }
-            } else if has_llm_key && benefit_category_empty && other_details_all_filled {
+            } else if benefit_category_empty && other_details_all_filled {
                 let inferred = infer_category_and_benefit(
                     &claim.merchant,
                     &claim.description,
                     &benefits,
                     args.openai_api_key.as_deref(),
-                    args.github_token.as_deref(),
+                    args.github_models_token.as_deref(),
+                    args.copilot_cli_path.as_deref(),
                 )?;
                 claim.benefit = inferred.benefit;
                 claim.category = inferred.category;
@@ -102,13 +103,9 @@ pub fn run(args: SubmitClaimsFromCsvArgs) -> Result<()> {
                 } else {
                     create_claim(&opts)
                 }
-            } else if has_llm_key {
-                anyhow::bail!(
-                    "To use LLM inference, a row must either leave every column except `receiptPath` blank (full receipt inference), or fill every column except `benefit` and `category` (benefit/category inference only)."
-                );
             } else {
                 anyhow::bail!(
-                    "You must either fill out the `benefit` and `category` columns, or specify an OpenAI API key or GitHub token."
+                    "To use LLM inference, a row must either leave every column except `receiptPath` blank (full receipt inference), or fill every column except `benefit` and `category` (benefit/category inference only)."
                 );
             }
         })();

--- a/src/commands/submit_claims_from_directory.rs
+++ b/src/commands/submit_claims_from_directory.rs
@@ -73,12 +73,6 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
     verbose::set(args.verbose);
     let access_token = resolve_access_token(args.access_token.as_deref())?;
 
-    if args.openai_api_key.is_none() && args.github_token.is_none() {
-        bail!(
-            "You must provide either an OpenAI API key (--openai-api-key) or GitHub token (--github-token) to infer claim details from receipts."
-        );
-    }
-
     let processed_directory = args
         .processed_directory
         .clone()
@@ -149,7 +143,8 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
                 receipt_file,
                 &benefits,
                 args.openai_api_key.as_deref(),
-                args.github_token.as_deref(),
+                args.github_models_token.as_deref(),
+                args.copilot_cli_path.as_deref(),
             )?;
 
             println!("{}", "\nInferred claim details:".green());

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,12 +1,16 @@
-//! LLM-powered inference for claim metadata. Supports both the OpenAI API and
-//! the GitHub Models inference endpoint via the `async-openai` crate, which
-//! speaks the OpenAI chat-completions protocol.
+//! LLM-powered inference for claim metadata. Supports three providers:
+//!
+//! 1. The OpenAI API and 2. the GitHub Models inference endpoint, both spoken
+//!    via the `async-openai` crate (the OpenAI chat-completions protocol).
+//! 3. The GitHub Copilot CLI, via the `github-copilot-sdk` crate. This is the
+//!    default when no OpenAI API key or GitHub token has been provided.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
-use async_openai::Client;
+use async_openai::Client as OpenAiClient;
 use async_openai::config::OpenAIConfig;
 use async_openai::types::chat::{
     ChatCompletionRequestMessage, ChatCompletionRequestMessageContentPartImageArgs,
@@ -16,6 +20,8 @@ use async_openai::types::chat::{
 };
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use github_copilot_sdk::types::{Attachment, MessageOptions, SessionConfig};
+use github_copilot_sdk::{CliProgram, Client as CopilotClient, ClientOptions};
 use regex::Regex;
 use serde::Deserialize;
 
@@ -49,7 +55,7 @@ fn llm_api_base_override() -> Option<String> {
 
 /// Resolved configuration for an OpenAI-compatible API call.
 struct ApiConfig {
-    client: Client<OpenAIConfig>,
+    client: OpenAiClient<OpenAIConfig>,
     model: &'static str,
     api_base: String,
 }
@@ -70,6 +76,9 @@ fn resolve_api_config(
     let (base, key, model) = if let Some(key) = openai {
         (OPENAI_BASE, key, OPENAI_MODEL)
     } else if let Some(key) = github {
+        eprintln!(
+            "Warning: The GitHub Models provider is deprecated and may be removed in a future release. Consider switching to the GitHub Copilot CLI (the default, no extra configuration required) by unsetting GITHUB_MODELS_TOKEN, or use OpenAI by setting OPENAI_API_KEY or passing --openai-api-key."
+        );
         (GITHUB_MODELS_BASE, key, GITHUB_MODELS_MODEL)
     } else {
         bail!("You must either specify a GitHub token or an OpenAI API key.")
@@ -78,10 +87,41 @@ fn resolve_api_config(
     let base = llm_api_base_override().unwrap_or_else(|| base.to_string());
     let config = OpenAIConfig::new().with_api_base(&base).with_api_key(key);
     Ok(ApiConfig {
-        client: Client::with_config(config),
+        client: OpenAiClient::with_config(config),
         model,
         api_base: base,
     })
+}
+
+/// The inference backend selected for a request.
+enum Provider {
+    /// OpenAI or GitHub Models, spoken over the OpenAI chat-completions API.
+    OpenAiCompatible(Box<ApiConfig>),
+    /// The GitHub Copilot CLI, with an optional explicit path to the binary.
+    Copilot { cli_path: Option<PathBuf> },
+}
+
+/// Decide which inference provider to use. An OpenAI API key or GitHub token,
+/// when present, takes precedence (handled by [`resolve_api_config`]).
+/// Otherwise we fall back to the GitHub Copilot CLI.
+fn resolve_provider(
+    openai_api_key: Option<&str>,
+    github_token: Option<&str>,
+    copilot_cli_path: Option<&Path>,
+) -> Result<Provider> {
+    let has_openai = openai_api_key.is_some_and(|s| !s.is_empty());
+    let has_github = github_token.is_some_and(|s| !s.is_empty());
+
+    if has_openai || has_github {
+        Ok(Provider::OpenAiCompatible(Box::new(resolve_api_config(
+            openai_api_key,
+            github_token,
+        )?)))
+    } else {
+        Ok(Provider::Copilot {
+            cli_path: copilot_cli_path.map(Path::to_path_buf),
+        })
+    }
 }
 
 fn run_blocking<F: std::future::Future<Output = Result<String>>>(future: F) -> Result<String> {
@@ -152,6 +192,108 @@ async fn call_chat_completion(
         .ok_or_else(|| anyhow!("LLM returned an empty response."))
 }
 
+// ---------------------------------------------------------------------------
+// GitHub Copilot CLI inference
+// ---------------------------------------------------------------------------
+
+/// Search `PATH` for the `copilot` CLI binary. The SDK's auto-resolution does
+/// not scan `PATH` (only `COPILOT_CLI_PATH` and the bundled binary), so we do
+/// it ourselves to support a "just works" experience when the CLI is installed.
+fn detect_copilot_cli() -> Option<PathBuf> {
+    let names: &[&str] = if cfg!(windows) {
+        &["copilot.exe", "copilot"]
+    } else {
+        &["copilot"]
+    };
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        for name in names {
+            let candidate = dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// Run a single-shot prompt through the GitHub Copilot CLI and return the
+/// assistant's final text response. An optional base64-encoded image is sent
+/// as an attachment for vision inference.
+async fn copilot_complete(
+    cli_path: Option<&Path>,
+    prompt: String,
+    image: Option<(String, String)>,
+) -> Result<String> {
+    let program = match cli_path {
+        Some(path) => CliProgram::Path(path.to_path_buf()),
+        None => detect_copilot_cli().map_or(CliProgram::Resolve, CliProgram::Path),
+    };
+
+    if is_verbose() {
+        eprintln!("[verbose] > GitHub Copilot CLI inference (program: {program:?})");
+    }
+
+    let mut options = ClientOptions::default();
+    options.program = program;
+
+    let client = CopilotClient::start(options).await.context(
+        "Failed to start the GitHub Copilot CLI. Ensure the `copilot` CLI is installed and on your PATH, pass --copilot-cli-path, or set COPILOT_CLI_PATH.",
+    )?;
+
+    let result = copilot_run_session(&client, prompt, image).await;
+
+    // Always attempt to shut the CLI process down cleanly, regardless of
+    // whether the request succeeded.
+    let _ = client.stop().await;
+
+    result
+}
+
+async fn copilot_run_session(
+    client: &CopilotClient,
+    prompt: String,
+    image: Option<(String, String)>,
+) -> Result<String> {
+    let session = client
+        .create_session(SessionConfig::default().approve_all_permissions())
+        .await
+        .context("Failed to create a GitHub Copilot session")?;
+
+    let message = MessageOptions::new(prompt).with_wait_timeout(Duration::from_secs(120));
+    let message = match image {
+        Some((data, mime_type)) => message.with_attachments(vec![Attachment::Blob {
+            data,
+            mime_type,
+            display_name: Some("receipt".to_string()),
+        }]),
+        None => message,
+    };
+
+    let event = session
+        .send_and_wait(message)
+        .await
+        .context("The GitHub Copilot inference request failed")?;
+
+    let _ = session.disconnect().await;
+
+    let response = event
+        .and_then(|e| {
+            e.data
+                .get("content")
+                .and_then(|c| c.as_str())
+                .map(str::to_string)
+        })
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| anyhow!("GitHub Copilot returned an empty response."))?;
+
+    if is_verbose() {
+        eprintln!("[verbose] < GitHub Copilot response: {response}");
+    }
+
+    Ok(response)
+}
+
 fn user_text_message(text: String) -> Result<ChatCompletionRequestMessage> {
     let message = ChatCompletionRequestUserMessageArgs::default()
         .content(ChatCompletionRequestUserMessageContent::Text(text))
@@ -205,8 +347,9 @@ pub fn infer_category_and_benefit(
     benefits_with_categories: &[BenefitWithCategories],
     openai_api_key: Option<&str>,
     github_token: Option<&str>,
+    copilot_cli_path: Option<&Path>,
 ) -> Result<InferredCategoryAndBenefit> {
-    let config = resolve_api_config(openai_api_key, github_token)?;
+    let provider = resolve_provider(openai_api_key, github_token, copilot_cli_path)?;
 
     let valid_categories: Vec<String> = benefits_with_categories
         .iter()
@@ -226,8 +369,15 @@ pub fn infer_category_and_benefit(
         description,
     );
 
-    let messages = vec![user_text_message(prompt)?];
-    let response = run_blocking(call_chat_completion(&config, messages))?;
+    let response = match &provider {
+        Provider::OpenAiCompatible(config) => {
+            let messages = vec![user_text_message(prompt)?];
+            run_blocking(call_chat_completion(config, messages))?
+        }
+        Provider::Copilot { cli_path } => {
+            run_blocking(copilot_complete(cli_path.as_deref(), prompt, None))?
+        }
+    };
     let trimmed = response.trim().to_string();
 
     // Find the matching category to derive the benefit name.
@@ -279,17 +429,18 @@ pub fn infer_all_from_receipt(
     benefits_with_categories: &[BenefitWithCategories],
     openai_api_key: Option<&str>,
     github_token: Option<&str>,
+    copilot_cli_path: Option<&Path>,
 ) -> Result<ReceiptInferenceResult> {
-    let config = resolve_api_config(openai_api_key, github_token)?;
+    let provider = resolve_provider(openai_api_key, github_token, copilot_cli_path)?;
 
     let image_path = convert_to_image_if_needed(receipt_path)?;
     let image_b64 = encode_image_to_base64(&image_path)?;
+    let mime_type = image_mime_type(&image_path);
     // If we converted the receipt to a temporary JPEG, remove it now that
     // it's been encoded so we don't leak files into the temp directory.
     if image_path != receipt_path {
         let _ = std::fs::remove_file(&image_path);
     }
-    let data_url = format!("data:image/jpeg;base64,{image_b64}");
 
     let valid_categories: Vec<String> = benefits_with_categories
         .iter()
@@ -321,8 +472,18 @@ pub fn infer_all_from_receipt(
         "Your job is to analyze a receipt image and extract ALL required information for an expense claim. You must return a JSON object with the following fields:\n\n- amount: The total amount (e.g., \"25.99\")\n- merchant: The name of the merchant/store\n- purchaseDate: The date in YYYY-MM-DD format\n- description: A brief description of what was purchased\n- benefit: The most appropriate benefit category from the valid benefits list. Only benefits from the provided list are valid.\n- category: The most appropriate category from the valid categories list. Only categories from the provided list are valid.\n\nValid benefits:\n{valid_benefits_list}\n\nValid categories:\n{valid_categories_list}\n\nReturn ONLY a valid JSON object with these exact field names. Do not include any other text or formatting. Do not wrap the JSON object in a markdown code block syntax.",
     );
 
-    let messages = vec![user_text_and_image_message(prompt, data_url)?];
-    let raw = run_blocking(call_chat_completion(&config, messages))?;
+    let raw = match &provider {
+        Provider::OpenAiCompatible(config) => {
+            let data_url = format!("data:{mime_type};base64,{image_b64}");
+            let messages = vec![user_text_and_image_message(prompt, data_url)?];
+            run_blocking(call_chat_completion(config, messages))?
+        }
+        Provider::Copilot { cli_path } => run_blocking(copilot_complete(
+            cli_path.as_deref(),
+            prompt,
+            Some((image_b64, mime_type)),
+        ))?,
+    };
 
     // Strip markdown code fences if the model added them despite the prompt.
     let cleaned = raw
@@ -455,4 +616,22 @@ fn encode_image_to_base64(path: &Path) -> Result<String> {
     let bytes = std::fs::read(path)
         .with_context(|| format!("Failed to read image file at {}", path.display()))?;
     Ok(BASE64.encode(bytes))
+}
+
+/// Best-effort MIME type for an image based on its file extension, defaulting
+/// to `image/jpeg` (PDF receipts are converted to JPEG before this is called).
+fn image_mime_type(path: &Path) -> String {
+    match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("png") => "image/png",
+        Some("heic") => "image/heic",
+        Some("webp") => "image/webp",
+        Some("gif") => "image/gif",
+        _ => "image/jpeg",
+    }
+    .to_string()
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -367,15 +367,22 @@ fn submit_claim_submits_a_full_multipart_request_to_the_mock_server() {
 
 #[test]
 #[serial]
-fn submit_claim_without_required_args_or_llm_key_fails_with_explanation() {
+fn submit_claim_with_bogus_copilot_cli_path_fails_with_explanation() {
+    // With no OpenAI key or GitHub token, a receipt-only claim falls back to the
+    // GitHub Copilot CLI. Pointing at a non-existent CLI binary keeps the test
+    // hermetic (no real inference) while still exercising the fallback path.
     let (_server, mut cmd, _home) = cli_with_server();
     let receipt = make_fake_receipt();
     cmd.env("FORMANATOR_ACCESS_TOKEN", TOKEN)
-        .args(["submit-claim", "--receipt-path"])
+        .args([
+            "submit-claim",
+            "--copilot-cli-path",
+            "/no/such/copilot-cli-binary",
+            "--receipt-path",
+        ])
         .arg(receipt.path())
         .assert()
-        .failure()
-        .stderr(contains("OpenAI API key").or(contains("GitHub token")));
+        .failure();
 }
 
 #[test]

--- a/tests/llm_api.rs
+++ b/tests/llm_api.rs
@@ -145,6 +145,7 @@ fn infer_category_and_benefit_resolves_llm_response_to_benefit() {
         &bwcs,
         None,
         Some("test-github-token"),
+        None,
     )
     .expect("infer_category_and_benefit should succeed");
 
@@ -188,6 +189,7 @@ fn infer_category_and_benefit_errors_when_llm_returns_unknown_category() {
         &bwcs,
         None,
         Some("test-github-token"),
+        None,
     )
     .expect_err("should reject unknown category");
     assert!(
@@ -215,8 +217,9 @@ fn infer_all_from_receipt_parses_structured_json_response() {
 
     let receipt = fake_jpeg_receipt();
     let bwcs = fixture_benefits_with_categories();
-    let result = infer_all_from_receipt(receipt.path(), &bwcs, None, Some("test-github-token"))
-        .expect("infer_all_from_receipt should succeed");
+    let result =
+        infer_all_from_receipt(receipt.path(), &bwcs, None, Some("test-github-token"), None)
+            .expect("infer_all_from_receipt should succeed");
 
     mock.assert();
     assert_eq!(result.amount, "3670.00");
@@ -265,7 +268,7 @@ fn infer_all_from_receipt_rejects_invalid_date_format() {
 
     let receipt = fake_jpeg_receipt();
     let bwcs = fixture_benefits_with_categories();
-    let err = infer_all_from_receipt(receipt.path(), &bwcs, None, Some("test-github-token"))
+    let err = infer_all_from_receipt(receipt.path(), &bwcs, None, Some("test-github-token"), None)
         .expect_err("should reject bad date");
     assert!(format!("{err}").contains("invalid date format"), "{err}");
 }
@@ -297,8 +300,9 @@ fn infer_all_from_receipt_strips_markdown_code_fences() {
 
     let receipt = fake_jpeg_receipt();
     let bwcs = fixture_benefits_with_categories();
-    let result = infer_all_from_receipt(receipt.path(), &bwcs, None, Some("test-github-token"))
-        .expect("should parse fenced JSON");
+    let result =
+        infer_all_from_receipt(receipt.path(), &bwcs, None, Some("test-github-token"), None)
+            .expect("should parse fenced JSON");
     assert_eq!(result.amount, "42.00");
     assert_eq!(result.category, "University Program");
 }
@@ -309,14 +313,16 @@ fn infer_all_from_receipt_strips_markdown_code_fences() {
 
 #[test]
 #[serial]
-fn infer_category_and_benefit_errors_when_no_key_is_provided() {
-    // No server mock is needed — resolve_api_config must fail before any
-    // HTTP request is attempted.
+fn infer_category_and_benefit_falls_back_to_copilot_and_fails_with_bogus_cli_path() {
+    // With no OpenAI key or GitHub token, inference falls back to the GitHub
+    // Copilot CLI. Pointing at a non-existent CLI binary must surface an error
+    // rather than silently succeeding — this keeps the test hermetic even in
+    // environments where a real `copilot` binary is on PATH.
     let bwcs = fixture_benefits_with_categories();
-    let err =
-        infer_category_and_benefit("m", "d", &bwcs, None, None).expect_err("should require a key");
-    assert!(
-        format!("{err}").contains("GitHub token or an OpenAI API key"),
-        "{err}"
-    );
+    let bogus = std::path::Path::new("/no/such/copilot-cli-binary");
+    let err = infer_category_and_benefit("m", "d", &bwcs, None, None, Some(bogus))
+        .expect_err("should fail to launch the bogus Copilot CLI");
+    // Just assert that an error was produced; the exact message comes from the
+    // SDK / OS and is not stable across platforms.
+    assert!(!format!("{err}").is_empty(), "{err}");
 }


### PR DESCRIPTION
## Summary

Makes the **GitHub Copilot CLI** the default LLM inference backend for Formanator. It's now used for receipt analysis and category/benefit inference whenever no OpenAI API key or GitHub Models token is configured — no extra setup required if the `copilot` CLI is installed.

## Changes

- **Copilot CLI as default fallback** (`src/llm.rs`): added a `Provider` abstraction (`resolve_provider`) so inference dispatches to OpenAI, GitHub Models, or the Copilot CLI. Added PATH auto-detection (`detect_copilot_cli`) plus one-shot session helpers using `github-copilot-sdk` 1.0.1. Receipts are sent as base64 `Attachment::Blob`.
- **New `--copilot-cli-path` argument** (env `COPILOT_CLI_PATH`) on all three submit commands, to point at a specific CLI binary.
- **GitHub Models deprecation**: runtime warning on use, now recommending the zero-config Copilot CLI default first, then OpenAI.
- **Renamed argument/env var**: `--github-token` → `--github-models-token`, `GITHUB_TOKEN` → `GITHUB_MODELS_TOKEN`.
- **MSRV bump** to Rust 1.94 (required by `github-copilot-sdk` 1.0.1).
- Updated `README.md` and `AGENTS.md`.

## Provider precedence

1. OpenAI API key → OpenAI
2. GitHub Models token → GitHub Models (deprecated, warns)
3. neither → **GitHub Copilot CLI** (default)

## Validation

`cargo fmt --check`, `cargo clippy --all-features --all-targets -- -D warnings`, `cargo test --all-features`, and `cargo build --release` all pass. Tests that previously asserted "no key" errors were repurposed to point at a bogus Copilot CLI path so they stay hermetic.