### PR TITLE
Add MCP client login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,16 @@ Formanator can run as an MCP server over stdio so AI assistants can interact wit
 }
 ```
 
-The server exposes three tools:
+The server exposes six tools:
 
+- `auth_status` — check whether Formanator is logged in to Forma.
+- `login_start` — request a Forma magic link by email.
+- `login_complete` — complete login by pasting the emailed magic link.
 - `list_benefits_with_categories` — list all benefits with their categories and remaining balances.
 - `list_claims` — list claims, with optional filtering (currently only `in_progress`).
 - `create_claim` — create a new claim.
 
-You must be logged in (`formanator login`) before starting the MCP server.
+If you are not already logged in, use `login_start` and `login_complete` from your MCP client. You can still log in ahead of time with `formanator login`.
 
 To build a binary without MCP support (smaller binary, fewer dependencies):
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -2,7 +2,10 @@
 //! MCP clients such as Claude Desktop or VS Code's MCP integration. Modelled
 //! on the corresponding implementation in [`timrogers/litra-rs`].
 
-use std::path::PathBuf;
+use std::{
+    path::PathBuf,
+    sync::{Arc, RwLock},
+};
 
 use anyhow::Result;
 use rmcp::{
@@ -13,11 +16,33 @@ use rmcp::{
 
 use crate::claims::{ClaimInput, claim_input_to_create_options};
 use crate::cli::McpArgs;
-use crate::config::resolve_access_token;
-use crate::forma::{ClaimsFilter, create_claim, get_benefits_with_categories, get_claims_list};
+use crate::commands::login::parse_emailed_forma_magic_link;
+use crate::config::{Config, get_access_token, read_config, store_config};
+use crate::forma::{
+    ClaimsFilter, create_claim, exchange_id_and_tk_for_access_token, get_benefits_with_categories,
+    get_claims_list, request_magic_link,
+};
+
+const LOGIN_REQUIRED_MESSAGE: &str = "You aren't logged in to Forma. Use the `login_start` MCP tool to request a magic link, then call `login_complete` with the link from your email.";
 
 #[derive(serde::Deserialize, schemars::JsonSchema, Default)]
 pub struct ListBenefitsParams {}
+
+#[derive(serde::Deserialize, schemars::JsonSchema, Default)]
+pub struct AuthStatusParams {}
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+pub struct LoginStartParams {
+    /// Email address for the Forma account to log in to.
+    pub email: String,
+}
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+pub struct LoginCompleteParams {
+    /// The magic link emailed by Forma.
+    #[serde(rename = "magicLink")]
+    pub magic_link: String,
+}
 
 #[derive(serde::Deserialize, schemars::JsonSchema, Default)]
 pub struct ListClaimsParams {
@@ -49,29 +74,115 @@ pub struct CreateClaimParams {
 pub struct FormanatorMcpServer {
     #[allow(dead_code)]
     tool_router: ToolRouter<FormanatorMcpServer>,
-    access_token: String,
+    access_token: Arc<RwLock<Option<String>>>,
 }
 
 impl Default for FormanatorMcpServer {
     fn default() -> Self {
-        Self::new(String::new())
+        Self::new(None)
     }
 }
 
 #[tool_router]
 impl FormanatorMcpServer {
-    pub fn new(access_token: String) -> Self {
+    pub fn new(access_token: Option<String>) -> Self {
         Self {
             tool_router: Self::tool_router(),
-            access_token,
+            access_token: Arc::new(RwLock::new(access_token.filter(|token| !token.is_empty()))),
         }
     }
 
+    fn has_access_token(&self) -> Result<bool, McpError> {
+        self.access_token
+            .read()
+            .map(|token| token.as_ref().is_some_and(|token| !token.is_empty()))
+            .map_err(|_| McpError::internal_error("Authentication state lock is poisoned", None))
+    }
+
+    fn set_access_token(&self, access_token: String) -> Result<(), McpError> {
+        let mut token = self
+            .access_token
+            .write()
+            .map_err(|_| McpError::internal_error("Authentication state lock is poisoned", None))?;
+        *token = Some(access_token);
+        Ok(())
+    }
+
     fn token(&self) -> Result<String, McpError> {
-        if !self.access_token.is_empty() {
-            return Ok(self.access_token.clone());
-        }
-        resolve_access_token(None).map_err(|e| McpError::internal_error(e.to_string(), None))
+        self.access_token
+            .read()
+            .map_err(|_| McpError::internal_error("Authentication state lock is poisoned", None))?
+            .clone()
+            .filter(|token| !token.is_empty())
+            .ok_or_else(|| McpError::invalid_request(LOGIN_REQUIRED_MESSAGE, None))
+    }
+
+    fn complete_login(&self, magic_link: &str) -> Result<(), McpError> {
+        let (id, tk) = parse_emailed_forma_magic_link(magic_link)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        let access_token = exchange_id_and_tk_for_access_token(&id, &tk)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        store_access_token(&access_token)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        self.set_access_token(access_token)
+    }
+
+    #[tool(
+        description = "Check whether Formanator is logged in to Forma",
+        annotations(read_only_hint = true, open_world_hint = false)
+    )]
+    async fn auth_status(
+        &self,
+        Parameters(_params): Parameters<AuthStatusParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let authenticated = self.has_access_token()?;
+        let json = serde_json::to_string_pretty(&serde_json::json!({
+            "authenticated": authenticated,
+            "message": if authenticated {
+                "Formanator has a Forma access token."
+            } else {
+                LOGIN_REQUIRED_MESSAGE
+            },
+        }))
+        .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
+
+    #[tool(
+        description = "Start logging in to Forma by emailing a magic link",
+        annotations(
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn login_start(
+        &self,
+        Parameters(params): Parameters<LoginStartParams>,
+    ) -> Result<CallToolResult, McpError> {
+        request_magic_link(&params.email)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(
+            "Forma has emailed a magic link. Call `login_complete` with the magic link from that email.",
+        )]))
+    }
+
+    #[tool(
+        description = "Complete logging in to Forma with the emailed magic link",
+        annotations(
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn login_complete(
+        &self,
+        Parameters(params): Parameters<LoginCompleteParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.complete_login(&params.magic_link)?;
+        Ok(CallToolResult::success(vec![Content::text(
+            "You are now logged in to Forma. The access token has been stored locally.",
+        )]))
     }
 
     #[tool(
@@ -166,8 +277,24 @@ impl ServerHandler for FormanatorMcpServer {
     }
 }
 
+fn resolve_initial_access_token(explicit: Option<&str>) -> Result<Option<String>> {
+    if let Some(token) = explicit.filter(|token| !token.is_empty()) {
+        return Ok(Some(token.to_string()));
+    }
+    get_access_token()
+}
+
+fn store_access_token(access_token: &str) -> Result<()> {
+    let last_update_check_timestamp = read_config()?.and_then(|c| c.last_update_check_timestamp);
+    store_config(&Config {
+        access_token: access_token.to_string(),
+        email: None,
+        last_update_check_timestamp,
+    })
+}
+
 pub fn run(args: McpArgs) -> Result<()> {
-    let access_token = resolve_access_token(args.access_token.as_deref())?;
+    let access_token = resolve_initial_access_token(args.access_token.as_deref())?;
 
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -192,4 +319,144 @@ pub fn run(args: McpArgs) -> Result<()> {
         Ok::<(), anyhow::Error>(())
     })?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::{OsStr, OsString};
+
+    use httpmock::prelude::*;
+    use serial_test::serial;
+
+    use super::*;
+    use crate::{forma::set_api_base, keychain};
+
+    const TOKEN: &str = "mcp-login-token";
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+            let original = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.original {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    struct ApiBaseGuard;
+
+    impl ApiBaseGuard {
+        fn new(base: &str) -> Self {
+            set_api_base(Some(base.to_string()));
+            Self
+        }
+    }
+
+    impl Drop for ApiBaseGuard {
+        fn drop(&mut self) {
+            set_api_base(None);
+        }
+    }
+
+    fn result_text(result: CallToolResult) -> String {
+        let value = serde_json::to_value(result).expect("tool result serializes");
+        value["content"][0]["text"]
+            .as_str()
+            .expect("tool result includes text content")
+            .to_string()
+    }
+
+    fn magic_link(id: &str, tk: &str) -> String {
+        let inner = format!("https://api.joinforma.com/client/auth/v2/login/magic?id={id}&tk={tk}");
+        let encoded = url::form_urlencoded::byte_serialize(inner.as_bytes()).collect::<String>();
+        format!("https://joinforma.page.link/?link={encoded}")
+    }
+
+    #[test]
+    fn rejects_forma_tools_without_access_token() {
+        let server = FormanatorMcpServer::new(None);
+        let err = server.token().expect_err("token should be required");
+
+        assert!(err.message.contains("login_start"), "{err:?}");
+        assert!(err.message.contains("login_complete"), "{err:?}");
+    }
+
+    #[test]
+    fn resolve_initial_access_token_prefers_explicit_token() {
+        let token = resolve_initial_access_token(Some("from-mcp-arg")).expect("should resolve");
+
+        assert_eq!(token, Some("from-mcp-arg".to_string()));
+    }
+
+    #[tokio::test]
+    async fn auth_status_reports_unauthenticated_without_access_token() {
+        let server = FormanatorMcpServer::new(None);
+        let result = server
+            .auth_status(Parameters(AuthStatusParams {}))
+            .await
+            .expect("auth status should succeed");
+        let text = result_text(result);
+        let status: serde_json::Value = serde_json::from_str(&text).expect("valid JSON status");
+
+        assert_eq!(status["authenticated"], false);
+        assert!(
+            status["message"]
+                .as_str()
+                .expect("message")
+                .contains("login_start")
+        );
+    }
+
+    #[serial]
+    #[test]
+    fn login_complete_stores_token_and_updates_server_state() {
+        let _mock_keychain = EnvVarGuard::set("FORMANATOR_USE_MOCK_KEYCHAIN", "1");
+        keychain::init();
+        let config_dir = tempfile::tempdir().expect("temp config dir");
+        let config_path = config_dir.path().join(".formanator.toml");
+        let _config_path = EnvVarGuard::set("FORMANATOR_CONFIG_PATH", &config_path);
+
+        let server = MockServer::start();
+        let _api_base = ApiBaseGuard::new(&server.base_url());
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/client/auth/v2/login/magic")
+                .query_param("id", "the-id")
+                .query_param("tk", "the-tk")
+                .query_param("return_token", "true");
+            then.status(200).body(
+                serde_json::json!({
+                    "success": true,
+                    "data": {
+                        "auth_token": TOKEN
+                    }
+                })
+                .to_string(),
+            );
+        });
+
+        let mcp_server = FormanatorMcpServer::new(None);
+        mcp_server
+            .complete_login(&magic_link("the-id", "the-tk"))
+            .expect("login should complete");
+
+        mock.assert();
+        assert_eq!(mcp_server.token().expect("token should be stored"), TOKEN);
+    }
 }


### PR DESCRIPTION
## Summary
- allow the MCP server to start without a stored Forma access token
- add `auth_status`, `login_start`, and `login_complete` MCP tools for magic-link login inside MCP clients
- persist completed MCP logins through the existing local token storage path and update the running server state
- document the new MCP login tools

## Validation
- `cargo test --locked --all-features`
- `cargo build --release --locked`
- `cargo clippy --locked --workspace --all-features --all-targets -- -D warnings`

Note: `pre-commit run --all-files` could not be run because `pre-commit` is not installed in this environment.