### PR TITLE
Allow customizing the OpenAI base URL and model

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ When submitting a claim you can either provide every detail manually or let an L
 
 If both are configured, Formanator prefers OpenAI and otherwise falls back to the GitHub Copilot CLI.
 
+By default the OpenAI backend talks to OpenAI's API (`https://api.openai.com/v1`) using the `gpt-4o` model. You can point it at any OpenAI-compatible API (for example Azure OpenAI, OpenRouter or a local server) and choose a different model:
+
+- Set the base URL with the `OPENAI_BASE_URL` environment variable or `--openai-base-url`.
+- Set the model with the `OPENAI_MODEL` environment variable or `--openai-model`.
+
 ### Submitting claims in bulk
 
 #### Automatically submitting all receipts in a directory (recommended)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -117,6 +117,12 @@ pub struct SubmitClaimArgs {
     /// OpenAI API key used to infer claim details. Defaults to the `OPENAI_API_KEY` environment variable.
     #[arg(long, env = "OPENAI_API_KEY")]
     pub openai_api_key: Option<String>,
+    /// Base URL for an OpenAI-compatible API. Defaults to the `OPENAI_BASE_URL` environment variable, otherwise OpenAI's API (`https://api.openai.com/v1`).
+    #[arg(long, env = "OPENAI_BASE_URL")]
+    pub openai_base_url: Option<String>,
+    /// Model used for OpenAI-compatible inference. Defaults to the `OPENAI_MODEL` environment variable, otherwise `gpt-4o`.
+    #[arg(long, env = "OPENAI_MODEL")]
+    pub openai_model: Option<String>,
     /// Path to the GitHub Copilot CLI binary, used for inference when no OpenAI API key is provided. Defaults to the `COPILOT_CLI_PATH` environment variable, otherwise auto-detected on your PATH.
     #[arg(long, env = "COPILOT_CLI_PATH")]
     pub copilot_cli_path: Option<PathBuf>,
@@ -146,6 +152,12 @@ pub struct SubmitClaimsFromCsvArgs {
     /// OpenAI API key used to infer claim details for rows that leave columns blank.
     #[arg(long, env = "OPENAI_API_KEY")]
     pub openai_api_key: Option<String>,
+    /// Base URL for an OpenAI-compatible API. Defaults to the `OPENAI_BASE_URL` environment variable, otherwise OpenAI's API (`https://api.openai.com/v1`).
+    #[arg(long, env = "OPENAI_BASE_URL")]
+    pub openai_base_url: Option<String>,
+    /// Model used for OpenAI-compatible inference. Defaults to the `OPENAI_MODEL` environment variable, otherwise `gpt-4o`.
+    #[arg(long, env = "OPENAI_MODEL")]
+    pub openai_model: Option<String>,
     /// Path to the GitHub Copilot CLI binary, used for inference when no OpenAI API key is provided. Defaults to the `COPILOT_CLI_PATH` environment variable, otherwise auto-detected on your PATH.
     #[arg(long, env = "COPILOT_CLI_PATH")]
     pub copilot_cli_path: Option<PathBuf>,
@@ -171,6 +183,12 @@ pub struct SubmitClaimsFromDirectoryArgs {
     /// OpenAI API key used to infer claim details from receipts.
     #[arg(long, env = "OPENAI_API_KEY")]
     pub openai_api_key: Option<String>,
+    /// Base URL for an OpenAI-compatible API. Defaults to the `OPENAI_BASE_URL` environment variable, otherwise OpenAI's API (`https://api.openai.com/v1`).
+    #[arg(long, env = "OPENAI_BASE_URL")]
+    pub openai_base_url: Option<String>,
+    /// Model used for OpenAI-compatible inference. Defaults to the `OPENAI_MODEL` environment variable, otherwise `gpt-4o`.
+    #[arg(long, env = "OPENAI_MODEL")]
+    pub openai_model: Option<String>,
     /// Path to the GitHub Copilot CLI binary, used for inference when no OpenAI API key is provided. Defaults to the `COPILOT_CLI_PATH` environment variable, otherwise auto-detected on your PATH.
     #[arg(long, env = "COPILOT_CLI_PATH")]
     pub copilot_cli_path: Option<PathBuf>,

--- a/src/commands/submit_claim.rs
+++ b/src/commands/submit_claim.rs
@@ -5,7 +5,7 @@ use crate::claims::{ClaimInput, claim_input_to_create_options};
 use crate::cli::SubmitClaimArgs;
 use crate::config::resolve_access_token;
 use crate::forma::{create_claim, get_benefits_with_categories};
-use crate::llm::{infer_all_from_receipt, infer_category_and_benefit};
+use crate::llm::{LlmOptions, infer_all_from_receipt, infer_category_and_benefit};
 use crate::prompt::prompt;
 use crate::verbose;
 
@@ -22,11 +22,20 @@ pub fn run(args: SubmitClaimArgs) -> Result<()> {
         description,
         receipt_path,
         openai_api_key,
+        openai_base_url,
+        openai_model,
         copilot_cli_path,
         dry_run,
         verbose: _,
         ..
     } = args;
+
+    let llm_options = LlmOptions {
+        openai_api_key: openai_api_key.as_deref(),
+        openai_base_url: openai_base_url.as_deref(),
+        openai_model: openai_model.as_deref(),
+        copilot_cli_path: copilot_cli_path.as_deref(),
+    };
 
     if receipt_path.is_empty() {
         bail!("You must specify at least one --receipt-path.");
@@ -83,12 +92,7 @@ pub fn run(args: SubmitClaimArgs) -> Result<()> {
         // Full receipt inference mode. Uses OpenAI when a key is provided,
         // otherwise falls back to the GitHub Copilot CLI.
         let benefits = get_benefits_with_categories(&access_token)?;
-        let inferred = infer_all_from_receipt(
-            &receipt_path[0],
-            &benefits,
-            openai_api_key.as_deref(),
-            copilot_cli_path.as_deref(),
-        )?;
+        let inferred = infer_all_from_receipt(&receipt_path[0], &benefits, &llm_options)?;
 
         println!(
             "{}",
@@ -130,13 +134,8 @@ pub fn run(args: SubmitClaimArgs) -> Result<()> {
         // Legacy mode: infer benefit and category only. Uses OpenAI when a
         // key is provided, otherwise the GitHub Copilot CLI.
         let benefits = get_benefits_with_categories(&access_token)?;
-        let inferred = infer_category_and_benefit(
-            &merchant,
-            &description,
-            &benefits,
-            openai_api_key.as_deref(),
-            copilot_cli_path.as_deref(),
-        )?;
+        let inferred =
+            infer_category_and_benefit(&merchant, &description, &benefits, &llm_options)?;
 
         println!(
             "The LLM inferred that you should claim using the {} benefit and {} category. If that seems right, hit Enter. If not, press Ctrl+C to end your session.",

--- a/src/commands/submit_claims_from_csv.rs
+++ b/src/commands/submit_claims_from_csv.rs
@@ -5,7 +5,7 @@ use crate::claims::{claim_input_to_create_options, read_claims_from_csv};
 use crate::cli::SubmitClaimsFromCsvArgs;
 use crate::config::resolve_access_token;
 use crate::forma::{create_claim, get_benefits_with_categories};
-use crate::llm::{infer_all_from_receipt, infer_category_and_benefit};
+use crate::llm::{LlmOptions, infer_all_from_receipt, infer_category_and_benefit};
 use crate::verbose;
 
 pub fn run(args: SubmitClaimsFromCsvArgs) -> Result<()> {
@@ -23,6 +23,13 @@ pub fn run(args: SubmitClaimsFromCsvArgs) -> Result<()> {
 
     let benefits = get_benefits_with_categories(&access_token)?;
     let total = claims.len();
+
+    let llm_options = LlmOptions {
+        openai_api_key: args.openai_api_key.as_deref(),
+        openai_base_url: args.openai_base_url.as_deref(),
+        openai_model: args.openai_model.as_deref(),
+        copilot_cli_path: args.copilot_cli_path.as_deref(),
+    };
 
     for (index, mut claim) in claims.into_iter().enumerate() {
         let row_number = index + 2;
@@ -57,12 +64,8 @@ pub fn run(args: SubmitClaimsFromCsvArgs) -> Result<()> {
                         "To infer all claim details from the receipt, you must provide at least one path in the `receiptPath` column."
                     );
                 }
-                let inferred = infer_all_from_receipt(
-                    &claim.receipt_path[0],
-                    &benefits,
-                    args.openai_api_key.as_deref(),
-                    args.copilot_cli_path.as_deref(),
-                )?;
+                let inferred =
+                    infer_all_from_receipt(&claim.receipt_path[0], &benefits, &llm_options)?;
                 println!("Inferred amount: {}", inferred.amount);
                 println!("Inferred merchant: {}", inferred.merchant);
                 println!("Inferred purchase date: {}", inferred.purchase_date);
@@ -87,8 +90,7 @@ pub fn run(args: SubmitClaimsFromCsvArgs) -> Result<()> {
                     &claim.merchant,
                     &claim.description,
                     &benefits,
-                    args.openai_api_key.as_deref(),
-                    args.copilot_cli_path.as_deref(),
+                    &llm_options,
                 )?;
                 claim.benefit = inferred.benefit;
                 claim.category = inferred.category;

--- a/src/commands/submit_claims_from_directory.rs
+++ b/src/commands/submit_claims_from_directory.rs
@@ -9,7 +9,7 @@ use crate::claims::{ClaimInput, claim_input_to_create_options};
 use crate::cli::SubmitClaimsFromDirectoryArgs;
 use crate::config::resolve_access_token;
 use crate::forma::{create_claim, get_benefits_with_categories};
-use crate::llm::infer_all_from_receipt;
+use crate::llm::{LlmOptions, infer_all_from_receipt};
 use crate::prompt::prompt;
 use crate::verbose;
 
@@ -120,6 +120,13 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
     let mut processed = 0usize;
     let mut skipped = 0usize;
 
+    let llm_options = LlmOptions {
+        openai_api_key: args.openai_api_key.as_deref(),
+        openai_base_url: args.openai_base_url.as_deref(),
+        openai_model: args.openai_model.as_deref(),
+        copilot_cli_path: args.copilot_cli_path.as_deref(),
+    };
+
     for (index, receipt_file) in receipt_files.iter().enumerate() {
         let filename = receipt_file
             .file_name()
@@ -139,12 +146,7 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
 
         let outcome = (|| -> Result<bool> {
             println!("Analyzing receipt...");
-            let inferred = infer_all_from_receipt(
-                receipt_file,
-                &benefits,
-                args.openai_api_key.as_deref(),
-                args.copilot_cli_path.as_deref(),
-            )?;
+            let inferred = infer_all_from_receipt(receipt_file, &benefits, &llm_options)?;
 
             println!("{}", "\nInferred claim details:".green());
             println!("  Amount: {}", inferred.amount.yellow());

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -28,46 +28,59 @@ use serde::Deserialize;
 use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
+/// Default OpenAI API base URL, used when no override is supplied.
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
+/// Default chat-completions model, used when no override is supplied.
 const OPENAI_MODEL: &str = "gpt-4o";
 
-// Base-URL override for the LLM API. Production code never sets this; the
-// integration tests in `tests/llm_api.rs` use it to point
-// the OpenAI-compatible client at a local mock HTTP server instead of the
-// real OpenAI endpoint.
-static LLM_API_BASE: std::sync::RwLock<Option<String>> = std::sync::RwLock::new(None);
-
-/// Override the LLM API base URL used for OpenAI-compatible chat-completions
-/// calls. Passing `None` clears any previous override. This is exposed
-/// publicly so that integration tests can call it; production code should
-/// never do so.
-pub fn set_llm_api_base(base: Option<String>) {
-    if let Ok(mut guard) = LLM_API_BASE.write() {
-        *guard = base;
-    }
-}
-
-fn llm_api_base_override() -> Option<String> {
-    LLM_API_BASE.read().ok().and_then(|g| g.clone())
+/// User-configurable options controlling LLM inference: which backend to use
+/// and, for the OpenAI-compatible backend, the base URL and model.
+///
+/// The OpenAI-compatible backend is selected when [`LlmOptions::openai_api_key`]
+/// is present and non-empty; otherwise inference falls back to the GitHub
+/// Copilot CLI. The base URL and model overrides make it possible to talk to
+/// any OpenAI-compatible provider (e.g. Azure OpenAI, OpenRouter or a local
+/// server), and let the integration tests point the client at a mock server.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LlmOptions<'a> {
+    /// OpenAI API key. When present and non-empty, the OpenAI-compatible
+    /// backend is used; otherwise inference falls back to the Copilot CLI.
+    pub openai_api_key: Option<&'a str>,
+    /// Override for the OpenAI-compatible API base URL. Defaults to
+    /// [`OPENAI_BASE`].
+    pub openai_base_url: Option<&'a str>,
+    /// Override for the chat-completions model name. Defaults to
+    /// [`OPENAI_MODEL`].
+    pub openai_model: Option<&'a str>,
+    /// Explicit path to the GitHub Copilot CLI binary. When `None`, the binary
+    /// is auto-detected on `PATH`.
+    pub copilot_cli_path: Option<&'a Path>,
 }
 
 /// Resolved configuration for an OpenAI-compatible API call.
 struct ApiConfig {
     client: OpenAiClient<OpenAIConfig>,
-    model: &'static str,
+    model: String,
     api_base: String,
 }
 
-fn resolve_api_config(openai_api_key: Option<&str>) -> Result<ApiConfig> {
-    let openai = openai_api_key.filter(|s| !s.is_empty());
-
-    let (base, key, model) = if let Some(key) = openai {
-        (OPENAI_BASE, key, OPENAI_MODEL)
-    } else {
-        bail!("You must specify an OpenAI API key.")
+fn resolve_api_config(options: &LlmOptions) -> Result<ApiConfig> {
+    let key = match options.openai_api_key.filter(|s| !s.is_empty()) {
+        Some(key) => key,
+        None => bail!("You must specify an OpenAI API key."),
     };
 
-    let base = llm_api_base_override().unwrap_or_else(|| base.to_string());
+    let base = options
+        .openai_base_url
+        .filter(|s| !s.is_empty())
+        .unwrap_or(OPENAI_BASE)
+        .to_string();
+    let model = options
+        .openai_model
+        .filter(|s| !s.is_empty())
+        .unwrap_or(OPENAI_MODEL)
+        .to_string();
+
     let config = OpenAIConfig::new().with_api_base(&base).with_api_key(key);
     Ok(ApiConfig {
         client: OpenAiClient::with_config(config),
@@ -87,19 +100,16 @@ enum Provider {
 /// Decide which inference provider to use. An OpenAI API key, when present,
 /// takes precedence (handled by [`resolve_api_config`]). Otherwise we fall
 /// back to the GitHub Copilot CLI.
-fn resolve_provider(
-    openai_api_key: Option<&str>,
-    copilot_cli_path: Option<&Path>,
-) -> Result<Provider> {
-    let has_openai = openai_api_key.is_some_and(|s| !s.is_empty());
+fn resolve_provider(options: &LlmOptions) -> Result<Provider> {
+    let has_openai = options.openai_api_key.is_some_and(|s| !s.is_empty());
 
     if has_openai {
         Ok(Provider::OpenAiCompatible(Box::new(resolve_api_config(
-            openai_api_key,
+            options,
         )?)))
     } else {
         Ok(Provider::Copilot {
-            cli_path: copilot_cli_path.map(Path::to_path_buf),
+            cli_path: options.copilot_cli_path.map(Path::to_path_buf),
         })
     }
 }
@@ -136,7 +146,7 @@ async fn call_chat_completion(
     messages: Vec<ChatCompletionRequestMessage>,
 ) -> Result<String> {
     let request = CreateChatCompletionRequestArgs::default()
-        .model(config.model)
+        .model(config.model.as_str())
         .messages(messages)
         .build()
         .context("Failed to build chat completions request")?;
@@ -325,10 +335,9 @@ pub fn infer_category_and_benefit(
     merchant: &str,
     description: &str,
     benefits_with_categories: &[BenefitWithCategories],
-    openai_api_key: Option<&str>,
-    copilot_cli_path: Option<&Path>,
+    options: &LlmOptions,
 ) -> Result<InferredCategoryAndBenefit> {
-    let provider = resolve_provider(openai_api_key, copilot_cli_path)?;
+    let provider = resolve_provider(options)?;
 
     let valid_categories: Vec<String> = benefits_with_categories
         .iter()
@@ -406,10 +415,9 @@ pub struct ReceiptInferenceResult {
 pub fn infer_all_from_receipt(
     receipt_path: &Path,
     benefits_with_categories: &[BenefitWithCategories],
-    openai_api_key: Option<&str>,
-    copilot_cli_path: Option<&Path>,
+    options: &LlmOptions,
 ) -> Result<ReceiptInferenceResult> {
-    let provider = resolve_provider(openai_api_key, copilot_cli_path)?;
+    let provider = resolve_provider(options)?;
 
     let image_path = convert_to_image_if_needed(receipt_path)?;
     let image_b64 = encode_image_to_base64(&image_path)?;

--- a/tests/llm_api.rs
+++ b/tests/llm_api.rs
@@ -2,17 +2,14 @@
 //!
 //! These tests drive the LLM inference entry points against a local mock
 //! HTTP server (via [`httpmock`]) that impersonates the OpenAI-compatible
-//! `/chat/completions` endpoint. The real LLM base URL is overridden via
-//! [`formanator::llm::set_llm_api_base`] for the duration of each test, so
-//! no real network requests are ever made.
-//!
-//! The tests are serialised because they share a process-global LLM API
-//! base URL override.
+//! `/chat/completions` endpoint. Each test points the client at the mock
+//! server through [`formanator::llm::LlmOptions::openai_base_url`], so no real
+//! network requests are ever made.
 
 use std::io::Write;
 
 use formanator::forma::{Benefit, BenefitWithCategories, Category};
-use formanator::llm::{infer_all_from_receipt, infer_category_and_benefit, set_llm_api_base};
+use formanator::llm::{LlmOptions, infer_all_from_receipt, infer_category_and_benefit};
 use httpmock::prelude::*;
 use serial_test::serial;
 
@@ -20,27 +17,14 @@ use serial_test::serial;
 mod common;
 use common::fixture;
 
-/// RAII guard that sets the LLM API base for the duration of a test and
-/// clears it when dropped.
-struct LlmBaseGuard;
-
-impl LlmBaseGuard {
-    fn new(base: &str) -> Self {
-        set_llm_api_base(Some(base.to_string()));
-        Self
+/// Build [`LlmOptions`] that use the OpenAI-compatible backend with a test API
+/// key, pointed at the given mock-server base URL.
+fn openai_options(base_url: &str) -> LlmOptions<'_> {
+    LlmOptions {
+        openai_api_key: Some("test-openai-key"),
+        openai_base_url: Some(base_url),
+        ..Default::default()
     }
-}
-
-impl Drop for LlmBaseGuard {
-    fn drop(&mut self) {
-        set_llm_api_base(None);
-    }
-}
-
-fn llm_server() -> (MockServer, LlmBaseGuard) {
-    let server = MockServer::start();
-    let guard = LlmBaseGuard::new(&server.base_url());
-    (server, guard)
 }
 
 /// A minimal valid-looking JPEG file at a fixed path. Returned as a
@@ -128,7 +112,7 @@ fn fixture_benefits_with_categories() -> Vec<BenefitWithCategories> {
 #[test]
 #[serial]
 fn infer_category_and_benefit_resolves_llm_response_to_benefit() {
-    let (server, _guard) = llm_server();
+    let server = MockServer::start();
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/chat/completions")
@@ -143,8 +127,7 @@ fn infer_category_and_benefit_resolves_llm_response_to_benefit() {
         "Open University",
         "MBA tuition fee",
         &bwcs,
-        Some("test-openai-key"),
-        None,
+        &openai_options(&server.base_url()),
     )
     .expect("infer_category_and_benefit should succeed");
 
@@ -158,7 +141,7 @@ fn infer_category_and_benefit_resolves_llm_response_to_benefit() {
 #[test]
 #[serial]
 fn infer_category_and_benefit_errors_when_llm_returns_unknown_category() {
-    let (server, _guard) = llm_server();
+    let server = MockServer::start();
     // Build a chat-completion response whose `content` is not in the
     // category list we pass in.
     let body = serde_json::json!({
@@ -186,8 +169,7 @@ fn infer_category_and_benefit_errors_when_llm_returns_unknown_category() {
         "Merchant",
         "Description",
         &bwcs,
-        Some("test-openai-key"),
-        None,
+        &openai_options(&server.base_url()),
     )
     .expect_err("should reject unknown category");
     assert!(
@@ -203,7 +185,7 @@ fn infer_category_and_benefit_errors_when_llm_returns_unknown_category() {
 #[test]
 #[serial]
 fn infer_all_from_receipt_parses_structured_json_response() {
-    let (server, _guard) = llm_server();
+    let server = MockServer::start();
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/chat/completions")
@@ -215,7 +197,7 @@ fn infer_all_from_receipt_parses_structured_json_response() {
 
     let receipt = fake_jpeg_receipt();
     let bwcs = fixture_benefits_with_categories();
-    let result = infer_all_from_receipt(receipt.path(), &bwcs, Some("test-openai-key"), None)
+    let result = infer_all_from_receipt(receipt.path(), &bwcs, &openai_options(&server.base_url()))
         .expect("infer_all_from_receipt should succeed");
 
     mock.assert();
@@ -233,7 +215,7 @@ fn infer_all_from_receipt_parses_structured_json_response() {
 #[test]
 #[serial]
 fn infer_all_from_receipt_rejects_invalid_date_format() {
-    let (server, _guard) = llm_server();
+    let server = MockServer::start();
     // The model returns a JSON payload whose shape is valid but whose
     // `purchaseDate` is not YYYY-MM-DD. The validator must reject it.
     let inner = serde_json::json!({
@@ -265,7 +247,7 @@ fn infer_all_from_receipt_rejects_invalid_date_format() {
 
     let receipt = fake_jpeg_receipt();
     let bwcs = fixture_benefits_with_categories();
-    let err = infer_all_from_receipt(receipt.path(), &bwcs, Some("test-openai-key"), None)
+    let err = infer_all_from_receipt(receipt.path(), &bwcs, &openai_options(&server.base_url()))
         .expect_err("should reject bad date");
     assert!(format!("{err}").contains("invalid date format"), "{err}");
 }
@@ -275,7 +257,7 @@ fn infer_all_from_receipt_rejects_invalid_date_format() {
 fn infer_all_from_receipt_strips_markdown_code_fences() {
     // Some models wrap the JSON in ```json ... ``` despite the prompt.
     // The parser is expected to strip those fences.
-    let (server, _guard) = llm_server();
+    let server = MockServer::start();
     let inner = "```json\n{\n  \"amount\": \"42.00\",\n  \"merchant\": \"Open University\",\n  \"purchaseDate\": \"2026-01-15\",\n  \"description\": \"Course fee\",\n  \"benefit\": \"Flexible Reimbursement Account\",\n  \"category\": \"University Program\"\n}\n```";
     let body = serde_json::json!({
         "id": "chatcmpl-test-fenced",
@@ -297,7 +279,7 @@ fn infer_all_from_receipt_strips_markdown_code_fences() {
 
     let receipt = fake_jpeg_receipt();
     let bwcs = fixture_benefits_with_categories();
-    let result = infer_all_from_receipt(receipt.path(), &bwcs, Some("test-openai-key"), None)
+    let result = infer_all_from_receipt(receipt.path(), &bwcs, &openai_options(&server.base_url()))
         .expect("should parse fenced JSON");
     assert_eq!(result.amount, "42.00");
     assert_eq!(result.category, "University Program");
@@ -316,7 +298,11 @@ fn infer_category_and_benefit_falls_back_to_copilot_and_fails_with_bogus_cli_pat
     // where a real `copilot` binary is on PATH.
     let bwcs = fixture_benefits_with_categories();
     let bogus = std::path::Path::new("/no/such/copilot-cli-binary");
-    let err = infer_category_and_benefit("m", "d", &bwcs, None, Some(bogus))
+    let options = LlmOptions {
+        copilot_cli_path: Some(bogus),
+        ..Default::default()
+    };
+    let err = infer_category_and_benefit("m", "d", &bwcs, &options)
         .expect_err("should fail to launch the bogus Copilot CLI");
     // Just assert that an error was produced; the exact message comes from the
     // SDK / OS and is not stable across platforms.


### PR DESCRIPTION
Add `--openai-base-url` / `OPENAI_BASE_URL` and `--openai-model` /
`OPENAI_MODEL` options to the claim-submission commands so the
OpenAI-compatible backend can target any compatible provider (Azure
OpenAI, OpenRouter, a local server, etc.) and use a non-default model.

The OpenAI/Copilot inference inputs are now grouped into an `LlmOptions`
struct threaded through `infer_category_and_benefit` and
`infer_all_from_receipt`. This replaces the previous process-global
test-only base URL override (`set_llm_api_base`): the integration tests
now point the client at the mock server through `LlmOptions` directly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Meyte28nEaaKy2k1vQEGAw