### PR TITLE
Upgrade default OpenAI model from gpt-4o to gpt-4.1

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-4.1";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
## Summary

- Upgrades the default OpenAI model constant (`OPENAI_MODEL`) in `src/llm.rs` from `gpt-4o` to `gpt-4.1`
- `gpt-4.1` is OpenAI's latest flagship model with improved instruction following and vision capabilities
- Both text-only (category inference) and vision (receipt inference) flows benefit from this upgrade

## Test plan

- [ ] Run the category inference flow with an OpenAI API key and confirm it calls `gpt-4.1`
- [ ] Run the receipt inference flow with an image receipt and confirm vision extraction works correctly
- [ ] Verify existing tests pass (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ddq7uEqpJGTPHYCjbPC91

---
_Generated by [Claude Code](https://claude.ai/code/session_017ddq7uEqpJGTPHYCjbPC91)_