### PR TITLE
Update OpenAI default model to gpt-5.4-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Once a day, Formanator checks GitHub for a newer release. When one is available,
 When submitting a claim you can either provide every detail manually or let an LLM infer them. Two providers are supported:
 
 - **GitHub Copilot CLI** — _the default._ If you don't configure OpenAI, Formanator uses the [GitHub Copilot CLI](https://github.com/features/copilot/cli) for inference. Formanator detects the `copilot` binary on your `PATH` automatically; if it lives elsewhere, set the `COPILOT_CLI_PATH` environment variable or pass `--copilot-cli-path` with the path to the binary.
-- **OpenAI** — billed to your OpenAI account. Set the `OPENAI_API_KEY` environment variable, or pass `--openai-api-key`.
+- **OpenAI** — billed to your OpenAI account, using `gpt-5.4-mini` by default for receipt and category inference. Set the `OPENAI_API_KEY` environment variable, or pass `--openai-api-key`.
 
 If both are configured, Formanator prefers OpenAI and otherwise falls back to the GitHub Copilot CLI.
 

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point

--- a/tests/fixtures/llm_category_inference_response.json
+++ b/tests/fixtures/llm_category_inference_response.json
@@ -11,7 +11,7 @@
     }
   ],
   "created": 1776763214,
-  "model": "gpt-4.1-2025-04-14",
+  "model": "gpt-5.4-mini",
   "service_tier": "default",
   "system_fingerprint": "fp_test0000",
   "object": "chat.completion",

--- a/tests/fixtures/llm_receipt_inference_response.json
+++ b/tests/fixtures/llm_receipt_inference_response.json
@@ -11,7 +11,7 @@
     }
   ],
   "created": 1776763374,
-  "model": "gpt-4.1-2025-04-14",
+  "model": "gpt-5.4-mini",
   "service_tier": "default",
   "system_fingerprint": "fp_test0000",
   "object": "chat.completion",

--- a/tests/llm_api.rs
+++ b/tests/llm_api.rs
@@ -165,7 +165,7 @@ fn infer_category_and_benefit_errors_when_llm_returns_unknown_category() {
         "id": "chatcmpl-test-bad-0001",
         "object": "chat.completion",
         "created": 1_745_000_000,
-        "model": "gpt-4.1-2025-04-14",
+        "model": "gpt-5.4-mini",
         "choices": [{
             "index": 0,
             "message": {"role": "assistant", "content": "Total Nonsense"},
@@ -249,7 +249,7 @@ fn infer_all_from_receipt_rejects_invalid_date_format() {
         "id": "chatcmpl-test-bad-date",
         "object": "chat.completion",
         "created": 1_745_000_000,
-        "model": "gpt-4.1-2025-04-14",
+        "model": "gpt-5.4-mini",
         "choices": [{
             "index": 0,
             "message": {"role": "assistant", "content": inner},
@@ -281,7 +281,7 @@ fn infer_all_from_receipt_strips_markdown_code_fences() {
         "id": "chatcmpl-test-fenced",
         "object": "chat.completion",
         "created": 1_745_000_000,
-        "model": "gpt-4.1-2025-04-14",
+        "model": "gpt-5.4-mini",
         "choices": [{
             "index": 0,
             "message": {"role": "assistant", "content": inner},


### PR DESCRIPTION
### Motivation
- Move the OpenAI-mode default to a more modern model string while keeping existing behaviour and provider selection logic unchanged. 
- Ensure README and test fixtures reflect the chosen default so documentation and mocked responses stay consistent. 
- Keep the change narrow (string-level model update) to avoid API-surface or runtime changes.

### Description
- Change the OpenAI default model constant from `gpt-4o` to `gpt-5.4-mini` in `src/llm.rs` (`OPENAI_MODEL`).
- Update the README to document that OpenAI-mode inference uses `gpt-5.4-mini` by default for receipt and category inference.
- Refresh LLM test fixtures and inline mocked `/chat/completions` responses in `tests/fixtures/llm_receipt_inference_response.json`, `tests/fixtures/llm_category_inference_response.json`, and `tests/llm_api.rs` to reference `gpt-5.4-mini`.

### Testing
- Ran `cargo fmt --all`, which completed successfully.
- Ran `git diff --check` and basic repo checks (no formatting or diff errors reported) and observed `rustc --version` in the environment.
- Attempts to run `cargo test --locked --all-features` and `cargo build --release --locked` were blocked because the local `rustc` is `1.89.0` while the crate and dependencies require MSRV `1.94`, so full test/build could not be executed here; `pre-commit run --all-files` was not run because `pre-commit` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a0d1be64832c8df0e73230ff8cab)