### PR TITLE
Update default OpenAI model from gpt-4o to gpt-4.5-mini

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-4.5-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
## Summary
Updates the default OpenAI model used by the LLM module from `gpt-4o` to `gpt-4.5-mini`.

## Changes
- Changed `OPENAI_MODEL` constant in `src/llm.rs` from `"gpt-4o"` to `"gpt-4.5-mini"`

## Details
This change updates the default language model used for LLM API calls throughout the application. The new model `gpt-4.5-mini` replaces the previous `gpt-4o` model as the default choice for OpenAI API requests.

https://claude.ai/code/session_01PyxgFVzeCHmjHX5w4BvK1W