### PR TITLE
[codex] Use gpt-5.4-mini by default

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
## Summary
- change the default OpenAI model from `gpt-4o` to `gpt-5.4-mini`

## Why
- align the built-in OpenAI default with the requested newer model

## Impact
- OpenAI-backed inference now uses `gpt-5.4-mini` unless overridden elsewhere

## Validation
- `cargo build --release --locked`
- `cargo test --locked --all-features` (fails in this environment because `mcp::tests::login_complete_stores_token_and_updates_server_state` cannot bind a local `httpmock` server: `Operation not permitted`)