### PR TITLE
Update default OpenAI model from gpt-4o to gpt-5.4-mini

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
## Summary
Updates the default LLM model used for API requests from `gpt-4o` to `gpt-5.4-mini`.

## Changes
- Changed `OPENAI_MODEL` constant in `src/llm.rs` from `"gpt-4o"` to `"gpt-5.4-mini"`

## Details
This change updates the default model that will be used for all OpenAI API calls throughout the application. The new model `gpt-5.4-mini` will be used for LLM operations unless explicitly overridden elsewhere in the codebase.

https://claude.ai/code/session_011X886NwxBN27wKqcbLGXiU