### PR TITLE
Update default OpenAI model to GPT-5.4-mini

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
## Summary

Updates the default OpenAI model used for receipt and claim analysis from `gpt-4o` to `gpt-5.4-mini`.

## Changes

- Changed the default model constant in `src/llm.rs` from `gpt-4o` to `gpt-5.4-mini`

This change affects both receipt vision inference and category/benefit prediction when using the OpenAI API.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDdh4cQTQaKWJhxY2vwrP9)_