### PR TITLE
Update default OpenAI model to GPT-5.4-mini

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
## Summary
- Updates the default OpenAI model from `gpt-4o` to `gpt-5.4-mini`
- This improves performance and cost efficiency for LLM inference operations in expense claim processing

## Testing
- Existing tests should continue to pass with the new model
- Model inference behavior should remain consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)