### PR TITLE
Switch default OpenAI model to gpt-5.4-mini

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
### Motivation
- Update the default OpenAI chat-completions model to `gpt-5.4-mini` so the CLI uses the newer model for LLM-powered inference.

### Description
- Change the `OPENAI_MODEL` constant in `src/llm.rs` from `gpt-4o` to `gpt-5.4-mini`.

### Testing
- Ran `cargo fmt --all -- --check`, which completed successfully.
- Ran `git diff --check`, which completed successfully.
- `pre-commit run --all-files` was not run in this environment because `pre-commit` is not installed.
- `cargo test --locked --all-features` and `cargo build --release --locked` were not executed due to the local Rust toolchain being older than the crate MSRV (installed rustc 1.89.0 vs required 1.94).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a7040aec8832ca3c7cc7f9d537030)