### PR TITLE
[codex] update default openai model

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
## What changed
- Updated the default OpenAI model from `gpt-4o` to `gpt-5.4-mini` in `src/llm.rs`.

## Why
- This keeps the OpenAI-backed inference path aligned with the newer default model requested for the project.

## Impact
- Users who run Formanator with an OpenAI API key will now use `gpt-5.4-mini` by default for claim inference.
- No CLI flags or configuration values changed.

## Validation
- `cargo test --locked --all-features`
- `cargo build --release --locked`
- `pre-commit run --all-files` could not run in this environment because `pre-commit` is not installed.