### PR TITLE
Switch default OpenAI model to gpt-5.4-mini

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -613,3 +613,13 @@ fn image_mime_type(path: &Path) -> String {
     }
     .to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::OPENAI_MODEL;
+
+    #[test]
+    fn default_openai_model_is_gpt_4o() {
+        assert_eq!(OPENAI_MODEL, "gpt-4o");
+    }
+}

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
### Motivation
- Use a newer OpenAI chat-completions model by default, switching the configured model from `gpt-4o` to `gpt-5.4-mini`.

### Description
- Update the `OPENAI_MODEL` constant in `src/llm.rs` from `"gpt-4o"` to `"gpt-5.4-mini"`.

### Testing
- Ran `git diff --check` (clean), attempted `pre-commit run --all-files` (failed because `pre-commit` is not installed), and attempted `cargo test --locked --all-features` and `cargo build --release --locked` (both failed because the local `rustc 1.89.0` is below the repository MSRV `1.94`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a7375f55c832c90e55458f545b533)