### PR TITLE
[codex] update the default OpenAI model

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
## What changed
- Updated the default OpenAI model from `gpt-4o` to `gpt-5.4-mini` in `src/llm.rs`.

## Why
- This keeps the OpenAI fallback aligned with the newer default model requested for inference.

## Impact
- Users who rely on the OpenAI path without overriding the model will now send requests to `gpt-5.4-mini`.
- No other inference routing or CLI behavior changed.

## Validation
- `cargo test --locked --all-features`
- Test suite completed successfully except for one unrelated sandbox-specific failure in `mcp::tests::login_complete_stores_token_and_updates_server_state` because `httpmock` could not bind to `127.0.0.1:0` (`PermissionDenied`).