### PR TITLE
Update OpenAI model from gpt-4o to gpt-4.1

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-4.1";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
## Summary
Updates the default OpenAI model used by the LLM module from `gpt-4o` to `gpt-4.1`.

## Changes
- Changed `OPENAI_MODEL` constant in `src/llm.rs` from `"gpt-4o"` to `"gpt-4.1"`

## Details
This change updates the model version used for all LLM API calls throughout the application. The new model `gpt-4.1` will be used for any OpenAI API requests made by the LLM module.

https://claude.ai/code/session_01HYidAGyfDgfmo5JbEyNWrR