### PR TITLE
Upgrade default OpenAI model from gpt-4o to gpt-4.1

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-4.1";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
## Summary

Upgrades the default OpenAI model used for LLM inference from `gpt-4o` to `gpt-4.1`.

## Changes

- Updated `OPENAI_MODEL` constant in `src/llm.rs` from `gpt-4o` to `gpt-4.1`

This affects all OpenAI API calls made by the application for claim metadata inference and receipt analysis.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNBDNqV9Vx4iL2aJv9ZqWR)_