### PR TITLE
Update default OpenAI model to GPT-5.4-mini

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
### Motivation
- Use the newer `GPT-5.4-mini` model as the default for OpenAI-compatible chat completions instead of the previous `gpt-4o` constant.

### Description
- Update the `OPENAI_MODEL` constant in `src/llm.rs` from `"gpt-4o"` to `"gpt-5.4-mini"`.

### Testing
- No automated tests were run on this change per the request not to run tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cfb187454832c80a155b322ba1fa3)