### PR TITLE
Change default OpenAI model to GPT-5.4-mini

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
### Motivation
- Use the newer `GPT-5.4-mini` model as the default for OpenAI chat-completions instead of `gpt-4o` to benefit from updated model capabilities.

### Description
- Replace the `OPENAI_MODEL` constant in `src/llm.rs` from `"gpt-4o"` to `"gpt-5.4-mini"`, which changes the model passed to OpenAI-compatible chat completion calls.

### Testing
- No automated tests were run for this change, per the request (i.e., `cargo test --locked --all-features` and `pre-commit` were not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cfb1ebe2c832ca6f1268b784ec442)