### PR TITLE
Update default OpenAI model to GPT-5.4-mini

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
### Motivation
- Use the newer GPT-5.4-mini as the default OpenAI chat-completions model instead of the previous `gpt-4o` for LLM-powered inference.

### Description
- Change the `OPENAI_MODEL` constant in `src/llm.rs` from `"gpt-4o"` to `"gpt-5.4-mini"`.

### Testing
- No automated tests were run per user request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cfc45cf38832c894b2d00567c21ec)