### PR TITLE
Change default OpenAI model to gpt-5.4-mini

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
### Motivation
- Use a newer OpenAI chat model for LLM-powered inference by switching the default from `gpt-4o` to `gpt-5.4-mini`.

### Description
- Updated the `OPENAI_MODEL` constant in `src/llm.rs` from `"gpt-4o"` to `"gpt-5.4-mini"`.

### Testing
- No automated tests were run on this change per request; please run `pre-commit run --all-files` and `cargo test --locked --all-features` in CI or locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cfc521b20832cb5e0ab21cc29d85c)