### PR TITLE
Change default OpenAI model to GPT-5.4-mini

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
### Motivation
- Update the default OpenAI model used for LLM-powered inference to the newer `GPT-5.4-mini` model by changing the `OPENAI_MODEL` constant.

### Description
- Modified `src/llm.rs` to set `const OPENAI_MODEL: &str = "gpt-5.4-mini";` replacing the previous `gpt-4o` default.

### Testing
- No automated tests were run on this change per request (`cargo test --locked --all-features` was not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cfc4b24a4832c8806217ea240fd0d)