### PR TITLE
chore: update default OpenAI model from gpt-4o to gpt-5.4-mini

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -29,7 +29,7 @@ use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
-const OPENAI_MODEL: &str = "gpt-4o";
+const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
 // Base-URL override for the LLM API. Production code never sets this; the
 // integration tests in `tests/llm_api.rs` use it to point


### PR DESCRIPTION
## Summary

- Updates the default OpenAI model constant from `gpt-4o` to `gpt-5.4-mini`

## What changed and why

`gpt-5.4-mini` is the newer model replacing `gpt-4o` as the default. This keeps the tool using the latest available model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)