### PR TITLE
fix: remove unneeded wildcard pattern in submit_claim (unblocks CI)

### DIFF
--- a/src/commands/submit_claim.rs
+++ b/src/commands/submit_claim.rs
@@ -26,7 +26,6 @@ pub fn run(args: SubmitClaimArgs) -> Result<()> {
         openai_model,
         copilot_cli_path,
         dry_run,
-        verbose: _,
         ..
     } = args;
 


### PR DESCRIPTION
## Problem

Newer clippy (Rust 1.97 on CI) flags `verbose: _,` in `src/commands/submit_claim.rs` as `clippy::unneeded_wildcard_pattern`, because the following `..` already ignores the remaining fields. With `-D warnings`, this fails the `pre-commit` job on **main**, which is currently blocking **all** open Dependabot PRs (#743, #745, #746).

## Fix

Remove the redundant `verbose: _,` line. `verbose` is already consumed earlier via `verbose::set(args.verbose)`, and `..` covers the field.

## Notes

- Not caused by any dependency bump — this is a pre-existing lint failure on main surfaced by a newer clippy.
- Couldn't run clippy locally (host has Rust 1.92; repo needs 1.94+), so relying on CI to confirm green.

🤖 Opened by Claw on Tim's behalf.