### PR TITLE
chore: update Rust MSRV to 1.97

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - `src/cli.rs` defines the Clap CLI surface.
 - `src/commands/` contains one handler per subcommand.
 - `src/lib.rs` exposes shared modules such as Forma API access, claim handling, config, prompts, LLM integration, and MCP support.
-- The default feature set includes `mcp`; the crate targets Rust edition 2024 and has an MSRV of Rust 1.94.
+- The default feature set includes `mcp`; the crate targets Rust edition 2024 and has an MSRV of Rust 1.97.
 
 ## Working in this repository
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.md"
 categories = ["command-line-utilities"]
 keywords = ["forma", "joinforma", "benefits", "expenses", "claims"]
-rust-version = "1.94"
+rust-version = "1.97"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
### Motivation
- Bring the crate and repository guidance up to the current stable Rust release by raising the declared minimum supported Rust version from `1.94` to `1.97`.

### Description
- Update `rust-version` in `Cargo.toml` from `"1.94"` to `"1.97"`.
- Update repository guidance in `AGENTS.md` to reference MSRV `1.97` instead of `1.94`.
- Commit changes on the feature branch with message `chore: update Rust MSRV to 1.97`.

### Testing
- Ran `COPILOT_SKIP_CLI_DOWNLOAD=1 pre-commit run --all-files` and the hooks completed successfully after installing `rustfmt`/`clippy` for the `1.97.1` toolchain.
- Ran `COPILOT_SKIP_CLI_DOWNLOAD=1 cargo test --locked --all-features` which completed successfully.
- Ran `COPILOT_SKIP_CLI_DOWNLOAD=1 cargo build --release --locked` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a124e81fc832c9338ab7e45cf986a)