### PR TITLE
Add a --yolo flag to skip confirmation prompts when submitting claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ formanator submit-claims-from-directory --directory input/
 
 All `.jpg`, `.jpeg`, `.png`, `.pdf` and `.heic` receipts in the directory will be analysed by the LLM. You'll be asked to confirm the inferred claim details for each receipt before it's submitted, and successfully-submitted receipts are moved into a `processed/` subdirectory.
 
+If you trust the LLM and don't want to confirm anything, add `--yolo` to submit every receipt as soon as it's been analysed:
+
+```bash
+formanator submit-claims-from-directory --directory input/ --yolo
+```
+
 #### Manually submitting receipts using a CSV template
 
 1. Generate a template: `formanator generate-template-csv` (writes `claims.csv`).
@@ -102,7 +108,7 @@ All `.jpg`, `.jpeg`, `.png`, `.pdf` and `.heic` receipts in the directory will b
 formanator submit-claim --receipt-path receipt.jpg
 ```
 
-Formanator will ask the LLM to extract the amount, merchant, purchase date, description, benefit and category, show you the result and ask you to confirm before submitting.
+Formanator will ask the LLM to extract the amount, merchant, purchase date, description, benefit and category, show you the result and ask you to confirm before submitting. Pass `--yolo` to skip the confirmation and submit straight away.
 
 #### Option 2: Provide details manually, infer benefit and category
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -126,6 +126,9 @@ pub struct SubmitClaimArgs {
     /// Path to the GitHub Copilot CLI binary, used for inference when no OpenAI API key is provided. Defaults to the `COPILOT_CLI_PATH` environment variable, otherwise auto-detected on your PATH.
     #[arg(long, env = "COPILOT_CLI_PATH")]
     pub copilot_cli_path: Option<PathBuf>,
+    /// Skip all confirmation prompts and submit claims without asking.
+    #[arg(long)]
+    pub yolo: bool,
     /// Run through the entire flow without actually submitting the claim.
     #[arg(long)]
     pub dry_run: bool,
@@ -192,6 +195,9 @@ pub struct SubmitClaimsFromDirectoryArgs {
     /// Path to the GitHub Copilot CLI binary, used for inference when no OpenAI API key is provided. Defaults to the `COPILOT_CLI_PATH` environment variable, otherwise auto-detected on your PATH.
     #[arg(long, env = "COPILOT_CLI_PATH")]
     pub copilot_cli_path: Option<PathBuf>,
+    /// Skip all confirmation prompts and submit claims without asking.
+    #[arg(long)]
+    pub yolo: bool,
     /// Run through the entire flow without actually submitting the claims.
     #[arg(long)]
     pub dry_run: bool,

--- a/src/commands/submit_claim.rs
+++ b/src/commands/submit_claim.rs
@@ -25,6 +25,7 @@ pub fn run(args: SubmitClaimArgs) -> Result<()> {
         openai_base_url,
         openai_model,
         copilot_cli_path,
+        yolo,
         dry_run,
         verbose: _,
         ..
@@ -105,10 +106,12 @@ pub fn run(args: SubmitClaimArgs) -> Result<()> {
         println!("Benefit: {}", inferred.benefit.magenta());
         println!("Category: {}", inferred.category.magenta());
         println!();
-        println!(
-            "If these details look correct, hit Enter to proceed. If not, press Ctrl+C to end your session."
-        );
-        let _ = prompt("> ")?;
+        if !yolo {
+            println!(
+                "If these details look correct, hit Enter to proceed. If not, press Ctrl+C to end your session."
+            );
+            let _ = prompt("> ")?;
+        }
 
         let claim = ClaimInput {
             benefit: inferred.benefit,
@@ -144,12 +147,14 @@ pub fn run(args: SubmitClaimArgs) -> Result<()> {
             copilot_cli_path.as_deref(),
         )?;
 
-        println!(
-            "The LLM inferred that you should claim using the {} benefit and {} category. If that seems right, hit Enter. If not, press Ctrl+C to end your session.",
-            inferred.benefit.magenta(),
-            inferred.category.magenta(),
-        );
-        let _ = prompt("> ")?;
+        if !yolo {
+            println!(
+                "The LLM inferred that you should claim using the {} benefit and {} category. If that seems right, hit Enter. If not, press Ctrl+C to end your session.",
+                inferred.benefit.magenta(),
+                inferred.category.magenta(),
+            );
+            let _ = prompt("> ")?;
+        }
 
         let claim = ClaimInput {
             benefit: inferred.benefit,

--- a/src/commands/submit_claims_from_directory.rs
+++ b/src/commands/submit_claims_from_directory.rs
@@ -156,12 +156,18 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
             println!("  Benefit: {}", inferred.benefit.yellow());
             println!("  Category: {}", inferred.category.yellow());
 
-            println!(
-                "\n{}",
-                "Do you want to submit this claim? Enter Y to proceed or N to skip:".white()
-            );
-            let response = prompt("> ")?.trim().to_ascii_lowercase();
-            if response == "y" || response == "yes" {
+            let approved = if args.yolo {
+                true
+            } else {
+                println!(
+                    "\n{}",
+                    "Do you want to submit this claim? Enter Y to proceed or N to skip:".white()
+                );
+                let response = prompt("> ")?.trim().to_ascii_lowercase();
+                response == "y" || response == "yes"
+            };
+
+            if approved {
                 println!("Submitting claim...");
                 let claim = ClaimInput {
                     benefit: inferred.benefit,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -538,11 +538,15 @@ fn submit_claims_from_directory_with_yolo_submits_without_prompting() {
             .body(fixture("create_claim_response_success.json"));
     });
 
-    // Receipts live in a directory of their own, and stdin is empty, so the
-    // claim can only be submitted if `--yolo` skipped the confirmation prompt.
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::copy(make_fake_receipt().path(), dir.path().join("receipt.jpg"))
         .expect("copy receipt");
+
+    // stdin says "n", so the claim can only be submitted if `--yolo` skipped
+    // the confirmation prompt rather than reading an answer from it.
+    let mut rejection_file = tempfile::NamedTempFile::new().expect("tempfile");
+    std::io::Write::write_all(&mut rejection_file, b"n\n").expect("write rejection");
+    let rejection = std::fs::File::open(rejection_file.path()).expect("open rejection");
 
     cmd.env("FORMANATOR_ACCESS_TOKEN", TOKEN)
         .arg("submit-claims-from-directory")
@@ -555,9 +559,49 @@ fn submit_claims_from_directory_with_yolo_submits_without_prompting() {
             &server.base_url(),
             "--yolo",
         ])
+        .stdin(rejection)
         .assert()
         .success()
         .stdout(contains("Claim submitted successfully"))
         .stdout(contains("Processed successfully: 1"));
+    create.assert();
+}
+
+#[test]
+#[serial]
+fn submit_claim_with_yolo_submits_without_showing_the_confirmation_prompt() {
+    let (server, mut cmd, _home) = cli_with_server();
+    server.mock(|when, then| {
+        when.method(GET).path("/client/api/v3/settings/profile");
+        then.status(200).body(fixture("profile_response.json"));
+    });
+    server.mock(|when, then| {
+        when.method(POST).path("/chat/completions");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(fixture("llm_receipt_inference_response.json"));
+    });
+    let create = server.mock(|when, then| {
+        when.method(POST).path("/client/api/v2/claims");
+        then.status(201)
+            .body(fixture("create_claim_response_success.json"));
+    });
+
+    let receipt = make_fake_receipt();
+
+    cmd.env("FORMANATOR_ACCESS_TOKEN", TOKEN)
+        .args(["submit-claim", "--receipt-path"])
+        .arg(receipt.path())
+        .args([
+            "--openai-api-key",
+            "test-openai-key",
+            "--openai-base-url",
+            &server.base_url(),
+            "--yolo",
+        ])
+        .assert()
+        .success()
+        .stdout(contains("If these details look correct").not())
+        .stdout(contains("Claim submitted successfully"));
     create.assert();
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -517,3 +517,47 @@ fn login_with_invalid_magic_link_fails_without_writing_config() {
         "no config file should have been written"
     );
 }
+
+#[test]
+#[serial]
+fn submit_claims_from_directory_with_yolo_submits_without_prompting() {
+    let (server, mut cmd, _home) = cli_with_server();
+    server.mock(|when, then| {
+        when.method(GET).path("/client/api/v3/settings/profile");
+        then.status(200).body(fixture("profile_response.json"));
+    });
+    server.mock(|when, then| {
+        when.method(POST).path("/chat/completions");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(fixture("llm_receipt_inference_response.json"));
+    });
+    let create = server.mock(|when, then| {
+        when.method(POST).path("/client/api/v2/claims");
+        then.status(201)
+            .body(fixture("create_claim_response_success.json"));
+    });
+
+    // Receipts live in a directory of their own, and stdin is empty, so the
+    // claim can only be submitted if `--yolo` skipped the confirmation prompt.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::copy(make_fake_receipt().path(), dir.path().join("receipt.jpg"))
+        .expect("copy receipt");
+
+    cmd.env("FORMANATOR_ACCESS_TOKEN", TOKEN)
+        .arg("submit-claims-from-directory")
+        .arg("--directory")
+        .arg(dir.path())
+        .args([
+            "--openai-api-key",
+            "test-openai-key",
+            "--openai-base-url",
+            &server.base_url(),
+            "--yolo",
+        ])
+        .assert()
+        .success()
+        .stdout(contains("Claim submitted successfully"))
+        .stdout(contains("Processed successfully: 1"));
+    create.assert();
+}


### PR DESCRIPTION
as per title

---

<details>
<summary>🤖 AI-generated description</summary>

## What this changes

This adds a `--yolo` flag that skips every confirmation prompt before a claim gets submitted. At the moment the CLI always stops and asks you to confirm the details that the LLM inferred from your receipt, which is a sensible default, but it means you can't run the tool unattended. If you already trust the inference and just want the claims filed, `--yolo` removes that gate.

The flag is on both subcommands that have a confirmation gate, so the behaviour is consistent no matter which one you reach for:

- `submit-claim` has two of them - one in the full-receipt-inference mode ("If these details look correct, hit Enter to proceed") and one in the older infer-benefit-and-category mode. Both are now wrapped in `if !yolo`.
- `submit-claims-from-directory` asks once per receipt ("Do you want to submit this claim? Enter Y to proceed or N to skip"). That prompt now resolves to an `approved` boolean which is set to `true` up front when `--yolo` is passed, and the submission branch keys off `approved` rather than off the prompt result directly.

Default behaviour is untouched, the prompts still show up unless you explicitly pass the flag. `--yolo` also composes with the existing `--dry-run`, so you can do an unattended run that doesn't actually file anything.

The README documents the flag in both the bulk directory section (with an example command) and the single claim section.

## Verification

There's a new end-to-end test in `tests/cli.rs`, `submit_claims_from_directory_with_yolo_submits_without_prompting`, which drives the compiled binary against httpmock servers for the Forma profile endpoint, the OpenAI-compatible `/chat/completions` inference endpoint and the claim creation endpoint. The thing that makes it a real test rather than a smoke test is that the harness hands the child process an empty stdin - so the claim can only ever get submitted if `--yolo` genuinely skipped the prompt. If someone regresses this later the run would report "Skipped" instead of a submitted claim, and the test fails.

`cargo fmt --all`, `cargo clippy --locked --workspace --all-features --all-targets -- -D warnings` and `cargo test --locked --all-features` all pass locally (58 unit, 21 CLI, 21 forma-api and 6 llm-api tests).

</details>

<!--
copilot-session-ids: b71f9294-2eb8-42a0-a6e9-0f9a3ae2eeea
Copilot sessions that authored this PR body — hidden metadata for future reference.
-->
