### PR TITLE
Analyse all receipts up front, then confirm them back to back, and abort on provider failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,7 @@ formanator submit-claims-from-directory --directory input/
 
 All `.jpg`, `.jpeg`, `.png`, `.pdf` and `.heic` receipts in the directory will be analysed by the LLM. You'll be asked to confirm the inferred claim details for each receipt before it's submitted, and successfully-submitted receipts are moved into a `processed/` subdirectory.
 
-Every receipt is analysed up front, with a progress bar, so you can walk away while that runs and then confirm all of them back to back. If the LLM provider itself can't be reached — bad API key, missing model, Copilot CLI that won't start — Formanator stops straight away instead of failing its way through the rest of the directory. Add `--analyze-one-by-one` if you'd rather interleave the two, waiting for the LLM to analyse each receipt just before you confirm it:
-
-```bash
-formanator submit-claims-from-directory --directory input/ --analyze-one-by-one
-```
+Every receipt is analysed up front, with a progress bar, so you can walk away while that runs and then confirm all of them back to back. If the LLM provider itself can't be reached — bad API key, missing model, Copilot CLI that won't start — Formanator stops straight away instead of failing its way through the rest of the directory.
 
 #### Manually submitting receipts using a CSV template
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ formanator submit-claims-from-directory --directory input/
 
 All `.jpg`, `.jpeg`, `.png`, `.pdf` and `.heic` receipts in the directory will be analysed by the LLM. You'll be asked to confirm the inferred claim details for each receipt before it's submitted, and successfully-submitted receipts are moved into a `processed/` subdirectory.
 
-By default, analysis and confirmation are interleaved, so you have to wait for the LLM between each receipt. Add `--analyze-first` to analyse every receipt up front instead, so you can walk away while it runs and then confirm all of them back to back:
+Every receipt is analysed up front, so you can walk away while that runs and then confirm all of them back to back. Add `--analyze-one-by-one` if you'd rather interleave the two, waiting for the LLM to analyse each receipt just before you confirm it:
 
 ```bash
-formanator submit-claims-from-directory --directory input/ --analyze-first
+formanator submit-claims-from-directory --directory input/ --analyze-one-by-one
 ```
 
 #### Manually submitting receipts using a CSV template

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ formanator submit-claims-from-directory --directory input/
 
 All `.jpg`, `.jpeg`, `.png`, `.pdf` and `.heic` receipts in the directory will be analysed by the LLM. You'll be asked to confirm the inferred claim details for each receipt before it's submitted, and successfully-submitted receipts are moved into a `processed/` subdirectory.
 
-Every receipt is analysed up front, so you can walk away while that runs and then confirm all of them back to back. Add `--analyze-one-by-one` if you'd rather interleave the two, waiting for the LLM to analyse each receipt just before you confirm it:
+Every receipt is analysed up front, with a progress bar, so you can walk away while that runs and then confirm all of them back to back. If the LLM provider itself can't be reached — bad API key, missing model, Copilot CLI that won't start — Formanator stops straight away instead of failing its way through the rest of the directory. Add `--analyze-one-by-one` if you'd rather interleave the two, waiting for the LLM to analyse each receipt just before you confirm it:
 
 ```bash
 formanator submit-claims-from-directory --directory input/ --analyze-one-by-one

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ formanator submit-claims-from-directory --directory input/
 
 All `.jpg`, `.jpeg`, `.png`, `.pdf` and `.heic` receipts in the directory will be analysed by the LLM. You'll be asked to confirm the inferred claim details for each receipt before it's submitted, and successfully-submitted receipts are moved into a `processed/` subdirectory.
 
+By default, analysis and confirmation are interleaved, so you have to wait for the LLM between each receipt. Add `--analyze-first` to analyse every receipt up front instead, so you can walk away while it runs and then confirm all of them back to back:
+
+```bash
+formanator submit-claims-from-directory --directory input/ --analyze-first
+```
+
 #### Manually submitting receipts using a CSV template
 
 1. Generate a template: `formanator generate-template-csv` (writes `claims.csv`).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -192,6 +192,9 @@ pub struct SubmitClaimsFromDirectoryArgs {
     /// Path to the GitHub Copilot CLI binary, used for inference when no OpenAI API key is provided. Defaults to the `COPILOT_CLI_PATH` environment variable, otherwise auto-detected on your PATH.
     #[arg(long, env = "COPILOT_CLI_PATH")]
     pub copilot_cli_path: Option<PathBuf>,
+    /// Analyse every receipt up front, then confirm them all one after another.
+    #[arg(long)]
+    pub analyze_first: bool,
     /// Run through the entire flow without actually submitting the claims.
     #[arg(long)]
     pub dry_run: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -192,9 +192,9 @@ pub struct SubmitClaimsFromDirectoryArgs {
     /// Path to the GitHub Copilot CLI binary, used for inference when no OpenAI API key is provided. Defaults to the `COPILOT_CLI_PATH` environment variable, otherwise auto-detected on your PATH.
     #[arg(long, env = "COPILOT_CLI_PATH")]
     pub copilot_cli_path: Option<PathBuf>,
-    /// Analyse every receipt up front, then confirm them all one after another.
+    /// Analyse and confirm one receipt at a time, instead of analysing them all up front.
     #[arg(long)]
-    pub analyze_first: bool,
+    pub analyze_one_by_one: bool,
     /// Run through the entire flow without actually submitting the claims.
     #[arg(long)]
     pub dry_run: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -192,9 +192,6 @@ pub struct SubmitClaimsFromDirectoryArgs {
     /// Path to the GitHub Copilot CLI binary, used for inference when no OpenAI API key is provided. Defaults to the `COPILOT_CLI_PATH` environment variable, otherwise auto-detected on your PATH.
     #[arg(long, env = "COPILOT_CLI_PATH")]
     pub copilot_cli_path: Option<PathBuf>,
-    /// Analyse and confirm one receipt at a time, instead of analysing them all up front.
-    #[arg(long)]
-    pub analyze_one_by_one: bool,
     /// Run through the entire flow without actually submitting the claims.
     #[arg(long)]
     pub dry_run: bool,

--- a/src/commands/submit_claims_from_directory.rs
+++ b/src/commands/submit_claims_from_directory.rs
@@ -129,9 +129,11 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
         )
     };
 
-    // With --analyze-first every receipt is analysed up front so all the
-    // confirmation prompts happen together, without waiting for the LLM.
-    let pre_analyzed = if args.analyze_first {
+    // By default every receipt is analysed up front so all the confirmation
+    // prompts happen together, without waiting for the LLM in between.
+    let pre_analyzed = if args.analyze_one_by_one {
+        Vec::new()
+    } else {
         println!(
             "{}",
             format!(
@@ -156,8 +158,6 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
                 analyze(receipt_file)
             })
             .collect()
-    } else {
-        Vec::new()
     };
     let mut pre_analyzed = pre_analyzed.into_iter();
 

--- a/src/commands/submit_claims_from_directory.rs
+++ b/src/commands/submit_claims_from_directory.rs
@@ -1,7 +1,8 @@
 use std::fs;
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use chrono::Utc;
 use colored::Colorize;
 
@@ -9,7 +10,7 @@ use crate::claims::{ClaimInput, claim_input_to_create_options};
 use crate::cli::SubmitClaimsFromDirectoryArgs;
 use crate::config::resolve_access_token;
 use crate::forma::{create_claim, get_benefits_with_categories};
-use crate::llm::infer_all_from_receipt;
+use crate::llm::{infer_all_from_receipt, is_provider_error};
 use crate::prompt::prompt;
 use crate::verbose;
 
@@ -39,6 +40,39 @@ fn list_receipt_files(directory: &Path) -> Result<Vec<PathBuf>> {
     }
     files.sort();
     Ok(files)
+}
+
+const PROGRESS_WIDTH: usize = 30;
+
+/// Draw a single-line progress bar, rewriting it in place. Falls back to one
+/// plain line per receipt when stdout isn't a terminal, so piped output and CI
+/// logs stay readable.
+fn draw_progress(done: usize, total: usize, label: &str) {
+    let mut stdout = std::io::stdout();
+    if !stdout.is_terminal() {
+        println!("Analyzing receipt {done}/{total}: {label}");
+        return;
+    }
+    // \r returns to the start of the line and \x1b[K clears whatever the
+    // previous, possibly longer, filename left behind.
+    print!("\r\x1b[K{}", progress_line(done, total, label));
+    let _ = stdout.flush();
+}
+
+fn progress_line(done: usize, total: usize, label: &str) -> String {
+    let filled = (PROGRESS_WIDTH * done.min(total) / total.max(1)).min(PROGRESS_WIDTH);
+    let bar = format!(
+        "{}{}",
+        "\u{2588}".repeat(filled),
+        "\u{2591}".repeat(PROGRESS_WIDTH - filled)
+    );
+    format!("[{}] {done}/{total} {label}", bar.cyan())
+}
+
+fn finish_progress() {
+    if std::io::stdout().is_terminal() {
+        println!();
+    }
 }
 
 fn move_to_processed(source: &Path, processed_dir: &Path) -> Result<()> {
@@ -131,9 +165,8 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
 
     // By default every receipt is analysed up front so all the confirmation
     // prompts happen together, without waiting for the LLM in between.
-    let pre_analyzed = if args.analyze_one_by_one {
-        Vec::new()
-    } else {
+    let mut pre_analyzed = Vec::new();
+    if !args.analyze_one_by_one {
         println!(
             "{}",
             format!(
@@ -142,27 +175,35 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
             )
             .cyan()
         );
-        receipt_files
-            .iter()
-            .enumerate()
-            .map(|(index, receipt_file)| {
-                println!(
-                    "Analyzing receipt {}/{}: {}",
-                    index + 1,
-                    receipt_files.len(),
-                    receipt_file
-                        .file_name()
-                        .unwrap_or_default()
-                        .to_string_lossy()
+        for (index, receipt_file) in receipt_files.iter().enumerate() {
+            draw_progress(
+                index + 1,
+                receipt_files.len(),
+                &receipt_file
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy(),
+            );
+            let result = analyze(receipt_file);
+            // Nothing has been submitted yet, so a dead provider means bailing
+            // out now rather than making the user sit through the rest.
+            if let Err(error) = &result
+                && is_provider_error(error)
+            {
+                finish_progress();
+                return Err(result.unwrap_err()).context(
+                    "Aborted before reviewing any claims because the receipts could not be analysed",
                 );
-                analyze(receipt_file)
-            })
-            .collect()
-    };
+            }
+            pre_analyzed.push(result);
+        }
+        finish_progress();
+    }
     let mut pre_analyzed = pre_analyzed.into_iter();
 
     let mut processed = 0usize;
     let mut skipped = 0usize;
+    let mut aborted = false;
 
     for (index, receipt_file) in receipt_files.iter().enumerate() {
         let filename = receipt_file
@@ -249,8 +290,16 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
             Ok(true) => processed += 1,
             Ok(false) => skipped += 1,
             Err(e) => {
-                eprintln!("{}", format!("❌ Error processing {filename}: {e}").red());
+                eprintln!("{}", format!("❌ Error processing {filename}: {e:#}").red());
                 skipped += 1;
+                if is_provider_error(&e) {
+                    eprintln!(
+                        "{}",
+                        "Aborting: the remaining receipts can't be analysed.".red()
+                    );
+                    aborted = true;
+                    break;
+                }
             }
         }
     }
@@ -270,5 +319,40 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
             .blue()
         );
     }
+    if aborted {
+        bail!("Stopped early because the receipts could not be analysed.");
+    }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PROGRESS_WIDTH, progress_line};
+
+    fn blocks(line: &str) -> (usize, usize) {
+        (
+            line.matches('\u{2588}').count(),
+            line.matches('\u{2591}').count(),
+        )
+    }
+
+    #[test]
+    fn progress_line_fills_in_proportion_and_never_overflows() {
+        assert_eq!(blocks(&progress_line(0, 4, "a.jpg")), (0, PROGRESS_WIDTH));
+        assert_eq!(
+            blocks(&progress_line(2, 4, "a.jpg")),
+            (PROGRESS_WIDTH / 2, PROGRESS_WIDTH / 2)
+        );
+        assert_eq!(blocks(&progress_line(4, 4, "a.jpg")), (PROGRESS_WIDTH, 0));
+        // Degenerate inputs must not panic or overflow the bar.
+        assert_eq!(blocks(&progress_line(0, 0, "a.jpg")), (0, PROGRESS_WIDTH));
+        assert_eq!(blocks(&progress_line(9, 4, "a.jpg")), (PROGRESS_WIDTH, 0));
+    }
+
+    #[test]
+    fn progress_line_shows_the_count_and_the_receipt_name() {
+        let line = progress_line(3, 7, "receipt.jpg");
+        assert!(line.contains("3/7"), "{line}");
+        assert!(line.contains("receipt.jpg"), "{line}");
+    }
 }

--- a/src/commands/submit_claims_from_directory.rs
+++ b/src/commands/submit_claims_from_directory.rs
@@ -152,60 +152,52 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
 
     let benefits = get_benefits_with_categories(&access_token)?;
 
-    let analyze = |receipt_file: &Path| {
-        infer_all_from_receipt(
+    // Every receipt is analysed up front so all the confirmation prompts
+    // happen together, without waiting for the LLM in between.
+    println!(
+        "{}",
+        format!(
+            "Analyzing {} receipt(s) before review...",
+            receipt_files.len()
+        )
+        .cyan()
+    );
+    let mut analyzed = Vec::new();
+    for (index, receipt_file) in receipt_files.iter().enumerate() {
+        draw_progress(
+            index + 1,
+            receipt_files.len(),
+            &receipt_file
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy(),
+        );
+        let result = infer_all_from_receipt(
             receipt_file,
             &benefits,
             args.openai_api_key.as_deref(),
             args.openai_base_url.as_deref(),
             args.openai_model.as_deref(),
             args.copilot_cli_path.as_deref(),
-        )
-    };
-
-    // By default every receipt is analysed up front so all the confirmation
-    // prompts happen together, without waiting for the LLM in between.
-    let mut pre_analyzed = Vec::new();
-    if !args.analyze_one_by_one {
-        println!(
-            "{}",
-            format!(
-                "Analyzing {} receipt(s) before review...",
-                receipt_files.len()
-            )
-            .cyan()
         );
-        for (index, receipt_file) in receipt_files.iter().enumerate() {
-            draw_progress(
-                index + 1,
-                receipt_files.len(),
-                &receipt_file
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy(),
+        // Nothing has been submitted yet, so a dead provider means bailing
+        // out now rather than making the user sit through the rest.
+        if let Err(error) = &result
+            && is_provider_error(error)
+        {
+            finish_progress();
+            return Err(result.unwrap_err()).context(
+                "Aborted before reviewing any claims because the receipts could not be analysed",
             );
-            let result = analyze(receipt_file);
-            // Nothing has been submitted yet, so a dead provider means bailing
-            // out now rather than making the user sit through the rest.
-            if let Err(error) = &result
-                && is_provider_error(error)
-            {
-                finish_progress();
-                return Err(result.unwrap_err()).context(
-                    "Aborted before reviewing any claims because the receipts could not be analysed",
-                );
-            }
-            pre_analyzed.push(result);
         }
-        finish_progress();
+        analyzed.push(result);
     }
-    let mut pre_analyzed = pre_analyzed.into_iter();
+    finish_progress();
 
     let mut processed = 0usize;
     let mut skipped = 0usize;
-    let mut aborted = false;
 
-    for (index, receipt_file) in receipt_files.iter().enumerate() {
+    for (index, (receipt_file, inferred)) in receipt_files.iter().zip(analyzed).enumerate() {
         let filename = receipt_file
             .file_name()
             .unwrap_or_default()
@@ -223,13 +215,7 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
         );
 
         let outcome = (|| -> Result<bool> {
-            let inferred = match pre_analyzed.next() {
-                Some(inferred) => inferred?,
-                None => {
-                    println!("Analyzing receipt...");
-                    analyze(receipt_file)?
-                }
-            };
+            let inferred = inferred?;
 
             println!("{}", "\nInferred claim details:".green());
             println!("  Amount: {}", inferred.amount.yellow());
@@ -292,14 +278,6 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
             Err(e) => {
                 eprintln!("{}", format!("❌ Error processing {filename}: {e:#}").red());
                 skipped += 1;
-                if is_provider_error(&e) {
-                    eprintln!(
-                        "{}",
-                        "Aborting: the remaining receipts can't be analysed.".red()
-                    );
-                    aborted = true;
-                    break;
-                }
             }
         }
     }
@@ -318,9 +296,6 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
             )
             .blue()
         );
-    }
-    if aborted {
-        bail!("Stopped early because the receipts could not be analysed.");
     }
     Ok(())
 }

--- a/src/commands/submit_claims_from_directory.rs
+++ b/src/commands/submit_claims_from_directory.rs
@@ -117,6 +117,50 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
     println!();
 
     let benefits = get_benefits_with_categories(&access_token)?;
+
+    let analyze = |receipt_file: &Path| {
+        infer_all_from_receipt(
+            receipt_file,
+            &benefits,
+            args.openai_api_key.as_deref(),
+            args.openai_base_url.as_deref(),
+            args.openai_model.as_deref(),
+            args.copilot_cli_path.as_deref(),
+        )
+    };
+
+    // With --analyze-first every receipt is analysed up front so all the
+    // confirmation prompts happen together, without waiting for the LLM.
+    let pre_analyzed = if args.analyze_first {
+        println!(
+            "{}",
+            format!(
+                "Analyzing {} receipt(s) before review...",
+                receipt_files.len()
+            )
+            .cyan()
+        );
+        receipt_files
+            .iter()
+            .enumerate()
+            .map(|(index, receipt_file)| {
+                println!(
+                    "Analyzing receipt {}/{}: {}",
+                    index + 1,
+                    receipt_files.len(),
+                    receipt_file
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                );
+                analyze(receipt_file)
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let mut pre_analyzed = pre_analyzed.into_iter();
+
     let mut processed = 0usize;
     let mut skipped = 0usize;
 
@@ -138,15 +182,13 @@ pub fn run(args: SubmitClaimsFromDirectoryArgs) -> Result<()> {
         );
 
         let outcome = (|| -> Result<bool> {
-            println!("Analyzing receipt...");
-            let inferred = infer_all_from_receipt(
-                receipt_file,
-                &benefits,
-                args.openai_api_key.as_deref(),
-                args.openai_base_url.as_deref(),
-                args.openai_model.as_deref(),
-                args.copilot_cli_path.as_deref(),
-            )?;
+            let inferred = match pre_analyzed.next() {
+                Some(inferred) => inferred?,
+                None => {
+                    println!("Analyzing receipt...");
+                    analyze(receipt_file)?
+                }
+            };
 
             println!("{}", "\nInferred claim details:".green());
             println!("  Amount: {}", inferred.amount.yellow());

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -28,6 +28,27 @@ use serde::Deserialize;
 use crate::forma::BenefitWithCategories;
 use crate::verbose::is_enabled as is_verbose;
 
+/// Attached as context to failures that mean the LLM provider itself is
+/// unusable (bad credentials, missing model, unreachable API, Copilot CLI that
+/// won't start) rather than a problem with one particular receipt. Callers
+/// processing a batch use [`is_provider_error`] to abort instead of retrying
+/// every remaining receipt against a provider that can't answer.
+#[derive(Debug)]
+pub struct ProviderUnavailable;
+
+impl std::fmt::Display for ProviderUnavailable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "The LLM provider is unavailable")
+    }
+}
+
+impl std::error::Error for ProviderUnavailable {}
+
+/// Whether an inference failure came from the provider rather than the receipt.
+pub fn is_provider_error(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<ProviderUnavailable>().is_some()
+}
+
 const OPENAI_BASE: &str = "https://api.openai.com/v1";
 const OPENAI_MODEL: &str = "gpt-5.4-mini";
 
@@ -172,7 +193,8 @@ async fn call_chat_completion(
         .chat()
         .create(request)
         .await
-        .context("Failed to call chat completions endpoint")?;
+        .context("Failed to call chat completions endpoint")
+        .context(ProviderUnavailable)?;
 
     if is_verbose() {
         match serde_json::to_string(&response) {
@@ -235,9 +257,12 @@ async fn copilot_complete(
     let mut options = ClientOptions::default();
     options.program = program;
 
-    let client = CopilotClient::start(options).await.context(
-        "Failed to start the GitHub Copilot CLI. Ensure the `copilot` CLI is installed and on your PATH, pass --copilot-cli-path, or set COPILOT_CLI_PATH.",
-    )?;
+    let client = CopilotClient::start(options)
+        .await
+        .context(
+            "Failed to start the GitHub Copilot CLI. Ensure the `copilot` CLI is installed and on your PATH, pass --copilot-cli-path, or set COPILOT_CLI_PATH.",
+        )
+        .context(ProviderUnavailable)?;
 
     let result = copilot_run_session(&client, prompt, image).await;
 
@@ -256,7 +281,8 @@ async fn copilot_run_session(
     let session = client
         .create_session(SessionConfig::default().approve_all_permissions())
         .await
-        .context("Failed to create a GitHub Copilot session")?;
+        .context("Failed to create a GitHub Copilot session")
+        .context(ProviderUnavailable)?;
 
     let message = MessageOptions::new(prompt).with_wait_timeout(Duration::from_secs(120));
     let message = match image {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -569,8 +569,8 @@ fn submit_claims_from_directory_analyses_everything_before_prompting() {
         .clone();
     create.assert_calls(2);
 
-    // The point of the flag: no receipt is still waiting to be analysed by the
-    // time the first confirmation prompt is shown.
+    // No receipt is still waiting to be analysed by the time the first
+    // confirmation prompt is shown.
     let stdout = String::from_utf8(output).expect("utf-8 stdout");
     let last_analysis = stdout
         .rfind("Analyzing receipt 2/2")
@@ -582,54 +582,6 @@ fn submit_claims_from_directory_analyses_everything_before_prompting() {
         last_analysis < first_prompt,
         "all receipts should be analysed before the first prompt, got:\n{stdout}"
     );
-}
-
-#[test]
-#[serial]
-fn submit_claims_from_directory_analyze_one_by_one_interleaves_analysis_and_prompts() {
-    let (server, mut cmd, _home) = cli_with_server();
-    server.mock(|when, then| {
-        when.method(GET).path("/client/api/v3/settings/profile");
-        then.status(200).body(fixture("profile_response.json"));
-    });
-    server.mock(|when, then| {
-        when.method(POST).path("/chat/completions");
-        then.status(200)
-            .header("content-type", "application/json")
-            .body(fixture("llm_receipt_inference_response.json"));
-    });
-    let create = server.mock(|when, then| {
-        when.method(POST).path("/client/api/v2/claims");
-        then.status(201)
-            .body(fixture("create_claim_response_success.json"));
-    });
-
-    let dir = tempfile::tempdir().expect("tempdir");
-    for name in ["a.jpg", "b.jpg"] {
-        std::fs::copy(make_fake_receipt().path(), dir.path().join(name)).expect("copy receipt");
-    }
-    let mut approvals_file = tempfile::NamedTempFile::new().expect("tempfile");
-    std::io::Write::write_all(&mut approvals_file, b"y\ny\n").expect("write approvals");
-    let approvals = std::fs::File::open(approvals_file.path()).expect("open approvals");
-
-    cmd.env("FORMANATOR_ACCESS_TOKEN", TOKEN)
-        .arg("submit-claims-from-directory")
-        .arg("--directory")
-        .arg(dir.path())
-        .args([
-            "--openai-api-key",
-            "test-openai-key",
-            "--openai-base-url",
-            &server.base_url(),
-            "--analyze-one-by-one",
-        ])
-        .stdin(approvals)
-        .assert()
-        .success()
-        .stdout(contains("Analyzing receipt..."))
-        .stdout(contains("before review...").not())
-        .stdout(contains("Processed successfully: 2"));
-    create.assert_calls(2);
 }
 
 #[test]
@@ -675,44 +627,4 @@ fn submit_claims_from_directory_aborts_early_when_the_llm_provider_rejects_the_r
     // The second receipt is never sent, and the user is never prompted.
     inference.assert_calls(1);
     create.assert_calls(0);
-}
-
-#[test]
-#[serial]
-fn submit_claims_from_directory_one_by_one_also_stops_on_a_provider_failure() {
-    let (server, mut cmd, _home) = cli_with_server();
-    server.mock(|when, then| {
-        when.method(GET).path("/client/api/v3/settings/profile");
-        then.status(200).body(fixture("profile_response.json"));
-    });
-    let inference = server.mock(|when, then| {
-        when.method(POST).path("/chat/completions");
-        then.status(401)
-            .header("content-type", "application/json")
-            .body(r#"{"error":{"message":"Incorrect API key provided","type":"invalid_request_error","code":"invalid_api_key"}}"#);
-    });
-
-    let dir = tempfile::tempdir().expect("tempdir");
-    for name in ["a.jpg", "b.jpg"] {
-        std::fs::copy(make_fake_receipt().path(), dir.path().join(name)).expect("copy receipt");
-    }
-
-    cmd.env("FORMANATOR_ACCESS_TOKEN", TOKEN)
-        .arg("submit-claims-from-directory")
-        .arg("--directory")
-        .arg(dir.path())
-        .args([
-            "--openai-api-key",
-            "test-openai-key",
-            "--openai-base-url",
-            &server.base_url(),
-            "--analyze-one-by-one",
-        ])
-        .assert()
-        .failure()
-        .stderr(contains(
-            "Aborting: the remaining receipts can't be analysed.",
-        ));
-
-    inference.assert_calls(1);
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -517,3 +517,70 @@ fn login_with_invalid_magic_link_fails_without_writing_config() {
         "no config file should have been written"
     );
 }
+
+#[test]
+#[serial]
+fn submit_claims_from_directory_with_analyze_first_analyses_everything_before_prompting() {
+    let (server, mut cmd, _home) = cli_with_server();
+    server.mock(|when, then| {
+        when.method(GET).path("/client/api/v3/settings/profile");
+        then.status(200).body(fixture("profile_response.json"));
+    });
+    server.mock(|when, then| {
+        when.method(POST).path("/chat/completions");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(fixture("llm_receipt_inference_response.json"));
+    });
+    let create = server.mock(|when, then| {
+        when.method(POST).path("/client/api/v2/claims");
+        then.status(201)
+            .body(fixture("create_claim_response_success.json"));
+    });
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    for name in ["a.jpg", "b.jpg"] {
+        std::fs::copy(make_fake_receipt().path(), dir.path().join(name)).expect("copy receipt");
+    }
+
+    // `cli_with_server` hands back a `std::process::Command`, which has no
+    // `write_stdin`, so the approvals are piped in from a file instead.
+    let mut approvals_file = tempfile::NamedTempFile::new().expect("tempfile");
+    std::io::Write::write_all(&mut approvals_file, b"y\ny\n").expect("write approvals");
+    let approvals = std::fs::File::open(approvals_file.path()).expect("open approvals");
+
+    let output = cmd
+        .env("FORMANATOR_ACCESS_TOKEN", TOKEN)
+        .arg("submit-claims-from-directory")
+        .arg("--directory")
+        .arg(dir.path())
+        .args([
+            "--openai-api-key",
+            "test-openai-key",
+            "--openai-base-url",
+            &server.base_url(),
+            "--analyze-first",
+        ])
+        .stdin(approvals)
+        .assert()
+        .success()
+        .stdout(contains("Processed successfully: 2"))
+        .get_output()
+        .stdout
+        .clone();
+    create.assert_calls(2);
+
+    // The point of the flag: no receipt is still waiting to be analysed by the
+    // time the first confirmation prompt is shown.
+    let stdout = String::from_utf8(output).expect("utf-8 stdout");
+    let last_analysis = stdout
+        .rfind("Analyzing receipt 2/2")
+        .expect("second receipt analysed up front");
+    let first_prompt = stdout
+        .find("Do you want to submit this claim?")
+        .expect("confirmation prompt shown");
+    assert!(
+        last_analysis < first_prompt,
+        "all receipts should be analysed before the first prompt, got:\n{stdout}"
+    );
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -631,3 +631,88 @@ fn submit_claims_from_directory_analyze_one_by_one_interleaves_analysis_and_prom
         .stdout(contains("Processed successfully: 2"));
     create.assert_calls(2);
 }
+
+#[test]
+#[serial]
+fn submit_claims_from_directory_aborts_early_when_the_llm_provider_rejects_the_request() {
+    let (server, mut cmd, _home) = cli_with_server();
+    server.mock(|when, then| {
+        when.method(GET).path("/client/api/v3/settings/profile");
+        then.status(200).body(fixture("profile_response.json"));
+    });
+    // An auth failure is not something the next receipt will recover from.
+    let inference = server.mock(|when, then| {
+        when.method(POST).path("/chat/completions");
+        then.status(401)
+            .header("content-type", "application/json")
+            .body(r#"{"error":{"message":"Incorrect API key provided","type":"invalid_request_error","code":"invalid_api_key"}}"#);
+    });
+    let create = server.mock(|when, then| {
+        when.method(POST).path("/client/api/v2/claims");
+        then.status(201)
+            .body(fixture("create_claim_response_success.json"));
+    });
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    for name in ["a.jpg", "b.jpg"] {
+        std::fs::copy(make_fake_receipt().path(), dir.path().join(name)).expect("copy receipt");
+    }
+
+    cmd.env("FORMANATOR_ACCESS_TOKEN", TOKEN)
+        .arg("submit-claims-from-directory")
+        .arg("--directory")
+        .arg(dir.path())
+        .args([
+            "--openai-api-key",
+            "test-openai-key",
+            "--openai-base-url",
+            &server.base_url(),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("Aborted before reviewing any claims"));
+
+    // The second receipt is never sent, and the user is never prompted.
+    inference.assert_calls(1);
+    create.assert_calls(0);
+}
+
+#[test]
+#[serial]
+fn submit_claims_from_directory_one_by_one_also_stops_on_a_provider_failure() {
+    let (server, mut cmd, _home) = cli_with_server();
+    server.mock(|when, then| {
+        when.method(GET).path("/client/api/v3/settings/profile");
+        then.status(200).body(fixture("profile_response.json"));
+    });
+    let inference = server.mock(|when, then| {
+        when.method(POST).path("/chat/completions");
+        then.status(401)
+            .header("content-type", "application/json")
+            .body(r#"{"error":{"message":"Incorrect API key provided","type":"invalid_request_error","code":"invalid_api_key"}}"#);
+    });
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    for name in ["a.jpg", "b.jpg"] {
+        std::fs::copy(make_fake_receipt().path(), dir.path().join(name)).expect("copy receipt");
+    }
+
+    cmd.env("FORMANATOR_ACCESS_TOKEN", TOKEN)
+        .arg("submit-claims-from-directory")
+        .arg("--directory")
+        .arg(dir.path())
+        .args([
+            "--openai-api-key",
+            "test-openai-key",
+            "--openai-base-url",
+            &server.base_url(),
+            "--analyze-one-by-one",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains(
+            "Aborting: the remaining receipts can't be analysed.",
+        ));
+
+    inference.assert_calls(1);
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -520,7 +520,7 @@ fn login_with_invalid_magic_link_fails_without_writing_config() {
 
 #[test]
 #[serial]
-fn submit_claims_from_directory_with_analyze_first_analyses_everything_before_prompting() {
+fn submit_claims_from_directory_analyses_everything_before_prompting() {
     let (server, mut cmd, _home) = cli_with_server();
     server.mock(|when, then| {
         when.method(GET).path("/client/api/v3/settings/profile");
@@ -559,7 +559,6 @@ fn submit_claims_from_directory_with_analyze_first_analyses_everything_before_pr
             "test-openai-key",
             "--openai-base-url",
             &server.base_url(),
-            "--analyze-first",
         ])
         .stdin(approvals)
         .assert()
@@ -583,4 +582,52 @@ fn submit_claims_from_directory_with_analyze_first_analyses_everything_before_pr
         last_analysis < first_prompt,
         "all receipts should be analysed before the first prompt, got:\n{stdout}"
     );
+}
+
+#[test]
+#[serial]
+fn submit_claims_from_directory_analyze_one_by_one_interleaves_analysis_and_prompts() {
+    let (server, mut cmd, _home) = cli_with_server();
+    server.mock(|when, then| {
+        when.method(GET).path("/client/api/v3/settings/profile");
+        then.status(200).body(fixture("profile_response.json"));
+    });
+    server.mock(|when, then| {
+        when.method(POST).path("/chat/completions");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(fixture("llm_receipt_inference_response.json"));
+    });
+    let create = server.mock(|when, then| {
+        when.method(POST).path("/client/api/v2/claims");
+        then.status(201)
+            .body(fixture("create_claim_response_success.json"));
+    });
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    for name in ["a.jpg", "b.jpg"] {
+        std::fs::copy(make_fake_receipt().path(), dir.path().join(name)).expect("copy receipt");
+    }
+    let mut approvals_file = tempfile::NamedTempFile::new().expect("tempfile");
+    std::io::Write::write_all(&mut approvals_file, b"y\ny\n").expect("write approvals");
+    let approvals = std::fs::File::open(approvals_file.path()).expect("open approvals");
+
+    cmd.env("FORMANATOR_ACCESS_TOKEN", TOKEN)
+        .arg("submit-claims-from-directory")
+        .arg("--directory")
+        .arg(dir.path())
+        .args([
+            "--openai-api-key",
+            "test-openai-key",
+            "--openai-base-url",
+            &server.base_url(),
+            "--analyze-one-by-one",
+        ])
+        .stdin(approvals)
+        .assert()
+        .success()
+        .stdout(contains("Analyzing receipt..."))
+        .stdout(contains("before review...").not())
+        .stdout(contains("Processed successfully: 2"));
+    create.assert_calls(2);
 }


### PR DESCRIPTION
tldr i had 20 receipts and instead of waiting 20x ~5s and approve each of them separately i'd much rather run everything all at once, wait 100s (and do something else in the meantime) and then speedrun approving them

---

<details>
<summary>🤖 AI-generated description</summary>

## What this changes

`submit-claims-from-directory` used to interleave analysis and confirmation. For every receipt it printed "Analyzing receipt...", sat there for a few seconds waiting for the LLM, showed the inferred claim details and then asked for a Y/N. With a directory full of receipts that means being pulled back to the terminal over and over for a single keystroke, with a multi-second wait between each one.

Now all the receipts are analysed in one up front pass, and the confirmation prompts happen afterwards, back to back. The inline `infer_all_from_receipt(...)` call moved out of the review loop into that pass, which collects the `Result`s into a `Vec`, and the review loop zips `receipt_files` with the stored results and just does `inferred?`. Everything after that point (printing the inferred details, prompting, submitting, moving the receipt into `processed/`) is unchanged.

## Progress bar

While the up front pass runs it draws an in place bar:

```
[████████░░░░░░░░░░░░░░] 2/3 coffee-shop-receipt.jpg
```

The line is rewritten with `\r` and cleared with `\x1b[K` rather than just overwritten, because a long filename followed by a shorter one would otherwise leave the tail of the previous name sitting on the line. This only happens when stdout is a terminal. When it isn't (pipes, CI logs, the integration tests) it falls back to one plain `Analyzing receipt i/N: name` line per receipt so captured output stays readable. The terminal check is `std::io::IsTerminal` from the standard library, so no new dependency.

## Aborting early when the provider is dead

Previously any inference failure was recorded against its receipt and the run carried on, which meant a bad API key or a missing model made you watch the same error scroll past once per receipt before the command finally gave up.

`src/llm.rs` now has a `ProviderUnavailable` marker error, attached with `.context(...)` at the three call sites that mean the provider itself is unusable: the OpenAI-compatible chat completions call, starting the GitHub Copilot CLI, and creating a Copilot session. `is_provider_error(&anyhow::Error)` downcasts to it, and the up front pass bails out as soon as it sees one.

The distinction matters here. A receipt the LLM simply can't read is still a per receipt problem, still recoverable, and still counted as skipped exactly as it was before. Only a provider that can't answer at all stops the run, and because the abort happens during the up front pass it lands before the user has been prompted for anything and before any claim has been submitted. Per receipt error messages now print with `{e:#}` instead of `{e}`, so the full anyhow context chain shows up rather than only the outermost message.

`README.md` documents the new behaviour, the progress bar and the early abort.

## Verification

`cargo fmt --all`, `cargo clippy --locked --workspace --all-features --all-targets -- -D warnings` and `cargo test --locked --all-features` all pass locally on Rust 1.97.1, matching CI: 60 unit, 22 CLI, 21 forma-api and 6 llm-api tests.

Two new CLI integration tests run against httpmock servers for the Forma profile endpoint, the OpenAI-compatible `/chat/completions` endpoint and claim creation:

- `submit_claims_from_directory_analyses_everything_before_prompting` submits two receipts, asserts both claims were created, and asserts that the "Analyzing receipt 2/2" line appears in stdout before the first "Do you want to submit this claim?" prompt.
- `submit_claims_from_directory_aborts_early_when_the_llm_provider_rejects_the_request` makes `/chat/completions` return a 401 and asserts that the command fails, that the inference endpoint was called exactly once (so the second receipt was never sent) and that zero claims were created.

There are also two unit tests on `progress_line` covering the fill arithmetic, including the degenerate `0/0` and overshoot cases that would otherwise panic or overflow the bar.

The terminal rendering path can't be exercised by the test harness, since stdout isn't a TTY there, so I checked it by hand instead: running the binary under a pty against a local mock server with three receipts, confirming the bar fills 10, 20 and 30 blocks in place and clears properly before the review phase starts.

## Note for existing users

This is a behaviour change. Prompts no longer start until every receipt has been analysed, and there is no opt out.

</details>

<!--
copilot-session-ids: b71f9294-2eb8-42a0-a6e9-0f9a3ae2eeea 65958d61-1fb5-43be-8176-dc23fd39f3ca
Copilot sessions that authored this PR body — hidden metadata for future reference.
-->
