### PR TITLE
Accept decoded Forma magic links

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To get started, you'll need to connect Formanator to your Forma account:
 1. Run `formanator login`.
 2. Press Enter to open your browser to the Forma login page.
 3. Enter your email address and request a magic link.
-4. Copy the magic link from your email and paste it into the terminal.
+4. Copy the magic link from your email and paste it into the terminal. Formanator accepts either the full `joinforma.page.link` URL or its decoded `client.joinforma.com/auth/magic` target.
 5. You're logged in 🥳
 
 The access token is securely stored in the system Keychain on macOS. On other platforms, it's stored in `~/.formanator.toml`.

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -14,23 +14,33 @@ const FORMA_LOGIN_URL: &str = "https://client.joinforma.com/login?type=magic";
 pub fn parse_emailed_forma_magic_link(input: &str) -> Result<(String, String)> {
     let parsed = Url::parse(input.trim()).context("Could not parse the input as a URL.")?;
 
-    if parsed.host_str() != Some("joinforma.page.link") {
-        bail!("Forma magic links are expected to have the hostname `joinforma.page.link`.");
-    }
     if parsed.scheme() != "https" {
         bail!("Forma magic links are expected to have the protocol `https:`.");
     }
 
-    let embedded = parsed
-        .query_pairs()
-        .find(|(k, _)| k == "link")
-        .map(|(_, v)| v.into_owned())
-        .ok_or_else(|| {
-            anyhow::anyhow!("Forma magic links are expected to have a `link` query parameter.")
-        })?;
+    let real_link = if parsed.host_str() == Some("joinforma.page.link") {
+        let embedded = parsed
+            .query_pairs()
+            .find(|(k, _)| k == "link")
+            .map(|(_, v)| v.into_owned())
+            .ok_or_else(|| {
+                anyhow::anyhow!("Forma magic links are expected to have a `link` query parameter.")
+            })?;
+        Url::parse(&embedded).context("The `link` query parameter is not a valid URL.")?
+    } else {
+        parsed
+    };
 
-    let real_link =
-        Url::parse(&embedded).context("The `link` query parameter is not a valid URL.")?;
+    let is_supported_target = matches!(
+        (real_link.host_str(), real_link.path()),
+        (Some("client.joinforma.com"), "/auth/magic")
+            | (Some("api.joinforma.com"), "/client/auth/v2/login/magic")
+    );
+    if real_link.scheme() != "https" || !is_supported_target {
+        bail!(
+            "Forma magic links are expected to target `https://client.joinforma.com/auth/magic`."
+        );
+    }
 
     let mut id = None;
     let mut tk = None;
@@ -128,8 +138,38 @@ mod tests {
     }
 
     #[test]
+    fn parses_a_current_emailed_magic_link() {
+        let inner = "https://client.joinforma.com/auth/magic?id=abc123&tk=xyz789";
+        let encoded = url::form_urlencoded::byte_serialize(inner.as_bytes()).collect::<String>();
+        let outer = format!("https://joinforma.page.link/?link={encoded}");
+
+        let (id, tk) = parse_emailed_forma_magic_link(&outer).expect("should parse");
+        assert_eq!(id, "abc123");
+        assert_eq!(tk, "xyz789");
+    }
+
+    #[test]
+    fn parses_a_decoded_current_magic_link() {
+        let link = "https://client.joinforma.com/auth/magic?id=abc123&tk=xyz789";
+
+        let (id, tk) = parse_emailed_forma_magic_link(link).expect("should parse");
+        assert_eq!(id, "abc123");
+        assert_eq!(tk, "xyz789");
+    }
+
+    #[test]
     fn rejects_links_with_the_wrong_host() {
         let result = parse_emailed_forma_magic_link("https://evil.example.com/?link=foo");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_wrappers_with_an_untrusted_inner_host() {
+        let inner = "https://evil.example.com/auth/magic?id=abc123&tk=xyz789";
+        let encoded = url::form_urlencoded::byte_serialize(inner.as_bytes()).collect::<String>();
+        let outer = format!("https://joinforma.page.link/?link={encoded}");
+
+        let result = parse_emailed_forma_magic_link(&outer);
         assert!(result.is_err());
     }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -507,6 +507,29 @@ fn login_with_magic_link_writes_config_to_home() {
 
 #[test]
 #[serial]
+fn login_with_decoded_current_magic_link_writes_config_to_home() {
+    let (server, mut cmd, _home) = cli_with_server();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/client/auth/v2/login/magic")
+            .query_param("id", "abc123")
+            .query_param("tk", "xyz789")
+            .query_param("return_token", "true");
+        then.status(200)
+            .body(fixture("magic_link_exchange_response.json"));
+    });
+
+    let link = "https://client.joinforma.com/auth/magic?id=abc123&tk=xyz789";
+
+    cmd.args(["login", "--magic-link", link])
+        .assert()
+        .success()
+        .stdout(contains("logged in"));
+    mock.assert();
+}
+
+#[test]
+#[serial]
 fn login_with_invalid_magic_link_fails_without_writing_config() {
     let (_server, mut cmd, home) = cli_with_server();
     cmd.args(["login", "--magic-link", "not a magic link"])


### PR DESCRIPTION
## Summary

- accept the current decoded `https://client.joinforma.com/auth/magic` URL in login flows
- continue supporting legacy `joinforma.page.link` wrapper URLs
- validate trusted inner hosts and paths so wrapper URLs cannot redirect parsing to arbitrary hosts
- document the supported link formats

## Why

The `joinforma.page.link` wrapper can return a browser 404, while its encoded `client.joinforma.com/auth/magic` target remains usable. Accepting the decoded target lets users complete login without relying on the wrapper redirect.

## Validation

- `cargo test --locked --all-features`
- `cargo build --release --locked`
- manually verified MCP login with a decoded current Forma magic link

`pre-commit` was not available locally; the equivalent Rust test and release-build checks passed.